### PR TITLE
fix: handle worker termination after worker exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -537,7 +537,9 @@ class Bree extends EventEmitter {
       if (Number.isFinite(closeWorkerAfterMs) && closeWorkerAfterMs > 0) {
         debug('worker has close set', name, closeWorkerAfterMs);
         this.closeWorkerAfterMs[name] = setTimeout(() => {
-          this.workers[name].terminate();
+          if (this.workers[name]) {
+            this.workers[name].terminate();
+          }
         }, closeWorkerAfterMs);
       }
 


### PR DESCRIPTION
Setting `closeWorkerAfterMs` causes for the worker to be terminated after the specified time. However, if the worker completes and exits normally before `closeWorkerAfterMs` milliseconds, the timeout created upon worker init is not cleared. This causes a `TypeError` where `this.workers[name]` is undefined and thus `this.workers[name].terminate` cannot be read or called. This PR adds a check upon timeout to ensure that `this.workers[name]` exists before calling `terminate`. This PR also fixes the test case `run > job terminates after set time`, which was not actually a proper test since the `Promise` in the test case was not `await`ed. The test failed to ensure that a worker that was properly terminated when termination was disabled.

I realized during the fix that there is a generic `stop` function that performs several cleanup tasks, one of which is clearing the timout set by `closeWorkerAfterMs`. I wasn't sure if it was appropriate to call `stop` during the exit stage of the worker, since the worker would technically already be stopped, so I leave it up to the maintainers to advise.