### PR TITLE
feat: added async support to stop method

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "is-string-and-not-blank": "^0.0.2",
     "is-valid-path": "^0.1.1",
     "ms": "^2.1.2",
+    "p-wait-for": "3.1.0",
     "safe-timers": "^1.1.0"
   },
   "devDependencies": {

--- a/test/jobs/message-process-exit.js
+++ b/test/jobs/message-process-exit.js
@@ -1,0 +1,12 @@
+const { parentPort } = require('bthreads');
+
+setInterval(() => {}, 10);
+
+if (parentPort) {
+  parentPort.on('message', (message) => {
+    if (message === 'cancel') {
+      // eslint-disable-next-line unicorn/no-process-exit
+      process.exit(0);
+    }
+  });
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1044,10 +1044,36 @@ test.serial('stop > job stops when "cancel" message is sent', async (t) => {
 
   t.is(typeof bree.workers.message, 'object');
 
-  bree.stop();
-  await delay(500);
+  await bree.stop();
 
   t.is(typeof bree.workers.message, 'undefined');
+});
+
+test.serial('stop > job stops when process.exit(0) is called', async (t) => {
+  t.plan(4);
+
+  const logger = _.cloneDeep(console);
+  logger.info = (message) => {
+    if (message === 'Worker for job "message-process-exit" exited with code 0')
+      t.true(true);
+  };
+
+  const bree = new Bree({
+    root,
+    jobs: [{ name: 'message-process-exit' }],
+    logger
+  });
+
+  t.is(typeof bree['message-process-exit'], 'undefined');
+
+  bree.start('message-process-exit');
+  await delay(1);
+
+  t.is(typeof bree.workers['message-process-exit'], 'object');
+
+  await bree.stop();
+
+  t.is(typeof bree.workers['message-process-exit'], 'undefined');
 });
 
 test.serial(

--- a/yarn.lock
+++ b/yarn.lock
@@ -6065,6 +6065,11 @@ p-defer@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
   integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
 p-is-promise@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-3.0.0.tgz#58e78c7dfe2e163cf2a04ff869e7c1dba64a5971"
@@ -6124,6 +6129,13 @@ p-reduce@^2.1.0:
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-2.1.0.tgz#09408da49507c6c274faa31f28df334bc712b64a"
   integrity sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==
 
+p-timeout@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
@@ -6133,6 +6145,13 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+p-wait-for@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-wait-for/-/p-wait-for-3.1.0.tgz#9da568a2adda3ea8175a3c43f46a5317e28c0e47"
+  integrity sha512-0Uy19uhxbssHelu9ynDMcON6BmMk6pH8551CvxROhiz3Vx+yC4RqxjyIDk2V4ll0g9177RKT++PK4zcV58uJ7A==
+  dependencies:
+    p-timeout "^3.0.0"
 
 package-hash@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
closes #34 

Adds async handling to stop method (graceful worker shutdown). Having async method does not break existing API and allows  clients in need of certainty for graceful worker shutdown to wait through `await bree.stop()` to finish all handling. 

This change also makes sure [process.exit(0)](https://nodejs.org/api/process.html#process_process_exit_code) (if executed from within worker thread) is treated the same way as current "graceful" shutdown is done with "cancelled" message. `process.exit(0)` should be treated as gracefull and more standard way of shutting down the worker as it's supported natively by worker_threads. From [documentation](https://nodejs.org/api/worker_threads.html#worker_threads_new_worker_filename_options):
> process.exit() does not stop the whole program, just the single thread, and process.abort() is not available.  