### PR TITLE
Refactored validateJob method complexity

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,8 @@
 const EventEmitter = require('events');
 const fs = require('fs');
-const { resolve, join } = require('path');
-
+const { resolve } = require('path');
 const pWaitFor = require('p-wait-for');
 const combineErrors = require('combine-errors');
-const cron = require('cron-validate');
 const debug = require('debug')('bree');
 const isSANB = require('is-string-and-not-blank');
 const isValidPath = require('is-valid-path');
@@ -20,6 +18,7 @@ const {
   getJobNames
 } = require('./job-utils');
 const buildJob = require('./job-builder');
+const validateJob = require('./job-validator');
 
 // bthreads requires us to do this for web workers (see bthreads docs for insight)
 threads.Buffer = Buffer;
@@ -106,7 +105,6 @@ class Bree extends EventEmitter {
     this.timeouts = {};
     this.intervals = {};
 
-    this.validateJob = this.validateJob.bind(this);
     this.isSchedule = isSchedule;
     this.getWorkerMetadata = this.getWorkerMetadata.bind(this);
     this.run = this.run.bind(this);
@@ -115,6 +113,7 @@ class Bree extends EventEmitter {
     this.add = this.add.bind(this);
     this.remove = this.remove.bind(this);
 
+    this.validateJob = validateJob;
     this.getName = getName;
     this.getHumanToMs = getHumanToMs;
     this.parseValue = parseValue;
@@ -184,7 +183,9 @@ class Bree extends EventEmitter {
       try {
         const names = getJobNames(this.config.jobs, i);
 
-        this.config.jobs[i] = this.validateJob(this.config.jobs[i], i, names);
+        validateJob(this.config.jobs[i], i, names, this.config);
+
+        this.config.jobs[i] = buildJob(this.config.jobs[i], this.config);
       } catch (err) {
         errors.push(err);
       }
@@ -194,283 +195,6 @@ class Bree extends EventEmitter {
     if (errors.length > 0) throw combineErrors(errors);
 
     debug('this.config.jobs', this.config.jobs);
-  }
-
-  // eslint-disable-next-line complexity
-  validateJob(job, i, names = []) {
-    const errors = [];
-
-    const name = this.getName(job);
-    if (!name) errors.push(new Error(`Job #${i + 1} is missing a name`));
-
-    // throw an error if duplicate job names
-    if (names.includes(name)) {
-      errors.push(
-        new Error(
-          `Job #${i + 1} has a duplicate job name of ${this.getName(job)}`
-        )
-      );
-    }
-
-    if (errors.length > 0) throw combineErrors(errors);
-
-    // support a simple string which we will transform to have a path
-    if (isSANB(job)) {
-      // don't allow a job to have the `index` file name
-      if (['index', 'index.js', 'index.mjs'].includes(job))
-        throw new Error(
-          'You cannot use the reserved job name of "index", "index.js", nor "index.mjs"'
-        );
-
-      if (!this.config.root) {
-        errors.push(
-          new Error(
-            `Job #${
-              i + 1
-            } "${job}" requires root directory option to auto-populate path`
-          )
-        );
-        throw combineErrors(errors);
-      }
-
-      const path = join(
-        this.config.root,
-        job.endsWith('.js') || job.endsWith('.mjs')
-          ? job
-          : `${job}.${this.config.defaultExtension}`
-      );
-
-      /* istanbul ignore next */
-      if (!threads.browser) {
-        const stats = fs.statSync(path);
-        if (!stats.isFile())
-          throw new Error(`Job #${i + 1} "${job}" path missing: ${path}`);
-      }
-
-      return buildJob(job, this.config);
-    }
-
-    // job is a function
-    if (typeof job === 'function') {
-      const path = `(${job.toString()})()`;
-      // can't be a built-in or bound function
-      if (path.includes('[native code]'))
-        errors.push(
-          new Error(`Job #${i + 1} can't be a bound or built-in function`)
-        );
-
-      if (errors.length > 0) throw combineErrors(errors);
-
-      return buildJob(job, this.config);
-    }
-
-    // use a prefix for errors
-    const prefix = `Job #${i + 1} named "${job.name}"`;
-
-    if (typeof job.path === 'function') {
-      const path = `(${job.path.toString()})()`;
-
-      // can't be a built-in or bound function
-      if (path.includes('[native code]'))
-        errors.push(
-          new Error(`Job #${i + 1} can't be a bound or built-in function`)
-        );
-    } else if (!isSANB(job.path) && !this.config.root) {
-      errors.push(
-        new Error(
-          `${prefix} requires root directory option to auto-populate path`
-        )
-      );
-    } else {
-      // validate path
-      const path = isSANB(job.path)
-        ? job.path
-        : join(
-            this.config.root,
-            job.name.endsWith('.js') || job.name.endsWith('.mjs')
-              ? job.name
-              : `${job.name}.${this.config.defaultExtension}`
-          );
-      if (isValidPath(path)) {
-        try {
-          /* istanbul ignore next */
-          if (!threads.browser) {
-            const stats = fs.statSync(path);
-            // eslint-disable-next-line max-depth
-            if (!stats.isFile())
-              throw new Error(`${prefix} path missing: ${path}`);
-          }
-        } catch (err) {
-          errors.push(err);
-        }
-      }
-    }
-
-    // don't allow users to mix interval AND cron
-    if (
-      typeof job.interval !== 'undefined' &&
-      typeof job.cron !== 'undefined'
-    ) {
-      errors.push(
-        new Error(`${prefix} cannot have both interval and cron configuration`)
-      );
-    }
-
-    // don't allow users to mix timeout AND date
-    if (typeof job.timeout !== 'undefined' && typeof job.date !== 'undefined')
-      errors.push(new Error(`${prefix} cannot have both timeout and date`));
-
-    // don't allow a job to have the `index` file name
-    if (['index', 'index.js', 'index.mjs'].includes(job.name)) {
-      errors.push(
-        new Error(
-          'You cannot use the reserved job name of "index", "index.js", nor "index.mjs"'
-        )
-      );
-
-      throw combineErrors(errors);
-    }
-
-    // validate date
-    if (typeof job.date !== 'undefined' && !(job.date instanceof Date))
-      errors.push(new Error(`${prefix} had an invalid Date of ${job.date}`));
-
-    // validate timeout
-    if (typeof job.timeout !== 'undefined') {
-      try {
-        this.parseValue(job.timeout);
-      } catch (err) {
-        errors.push(
-          combineErrors([
-            new Error(`${prefix} had an invalid timeout of ${job.timeout}`),
-            err
-          ])
-        );
-      }
-    }
-
-    // validate interval
-    if (typeof job.interval !== 'undefined') {
-      try {
-        this.parseValue(job.interval);
-      } catch (err) {
-        errors.push(
-          combineErrors([
-            new Error(`${prefix} had an invalid interval of ${job.interval}`),
-            err
-          ])
-        );
-      }
-    }
-
-    // validate hasSeconds
-    if (
-      typeof job.hasSeconds !== 'undefined' &&
-      typeof job.hasSeconds !== 'boolean'
-    )
-      errors.push(
-        new Error(
-          `${prefix} had hasSeconds value of ${job.hasSeconds} (it must be a Boolean)`
-        )
-      );
-
-    // validate cronValidate
-    if (
-      typeof job.cronValidate !== 'undefined' &&
-      typeof job.cronValidate !== 'object'
-    )
-      errors.push(
-        new Error(
-          `${prefix} had cronValidate value set, but it must be an Object`
-        )
-      );
-
-    // if `hasSeconds` was `true` then set `cronValidate` and inherit any existing options
-    if (job.hasSeconds) {
-      const preset =
-        job.cronValidate && job.cronValidate.preset
-          ? job.cronValidate.preset
-          : this.config.cronValidate && this.config.cronValidate.preset
-          ? this.config.cronValidate.preset
-          : 'default';
-      const override = {
-        ...(this.config.cronValidate && this.config.cronValidate.override
-          ? this.config.cronValidate.override
-          : {}),
-        ...(job.cronValidate && job.cronValidate.override
-          ? job.cronValidate.override
-          : {}),
-        useSeconds: true
-      };
-      job.cronValidate = {
-        ...this.config.cronValidate,
-        ...job.cronValidate,
-        preset,
-        override
-      };
-    }
-
-    // validate cron
-    if (typeof job.cron !== 'undefined') {
-      if (!this.isSchedule(job.cron)) {
-        //
-        // validate cron pattern
-        // (must support patterns such as `* * L * *` and `0 0/5 14 * * ?` (and aliases too)
-        //
-        //  <https://github.com/Airfooox/cron-validate/issues/67>
-        //
-        const result = cron(
-          job.cron,
-          typeof job.cronValidate === 'undefined'
-            ? this.config.cronValidate
-            : job.cronValidate
-        );
-
-        if (!result.isValid()) {
-          // NOTE: it is always valid
-          // const schedule = later.schedule(
-          //   later.parse.cron(
-          //     job.cron,
-          //     boolean(
-          //       typeof job.hasSeconds === 'undefined'
-          //         ? this.config.hasSeconds
-          //         : job.hasSeconds
-          //     )
-          //   )
-          // );
-          // if (schedule.isValid()) {
-          //   job.interval = schedule;
-          // } // else {
-          //   errors.push(
-          //     new Error(
-          //       `${prefix} had an invalid cron schedule (see <https://crontab.guru> if you need help)`
-          //     )
-          //   );
-          // }
-
-          for (const message of result.getError()) {
-            errors.push(
-              new Error(`${prefix} had an invalid cron pattern: ${message}`)
-            );
-          }
-        }
-      }
-    }
-
-    // validate closeWorkerAfterMs
-    if (
-      typeof job.closeWorkerAfterMs !== 'undefined' &&
-      (!Number.isFinite(job.closeWorkerAfterMs) || job.closeWorkerAfterMs <= 0)
-    )
-      errors.push(
-        new Error(
-          `${prefix} had an invalid closeWorkersAfterMs value of ${job.closeWorkersAfterMs} (it must be a finite number > 0)`
-        )
-      );
-
-    if (errors.length > 0) throw combineErrors(errors);
-
-    return buildJob(job, this.config);
   }
 
   getWorkerMetadata(name, meta = {}) {
@@ -756,7 +480,9 @@ class Bree extends EventEmitter {
           ...getJobNames(this.config.jobs)
         ];
 
-        const job = this.validateJob(job_, i, names);
+        validateJob(job_, i, names, this.config);
+        const job = buildJob(job_, this.config);
+
         this.config.jobs.push(job);
       } catch (err) {
         errors.push(err);

--- a/src/index.js
+++ b/src/index.js
@@ -214,7 +214,9 @@ class Bree extends EventEmitter {
       // throw an error if duplicate job names
       if (names.includes(name))
         errors.push(
-          new Error(`Job #${j + 1} has a duplicate job name of ${job}`)
+          new Error(
+            `Job #${j + 1} has a duplicate job name of ${this.getName(job)}`
+          )
         );
 
       names.push(name);

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,8 @@ const threads = require('bthreads');
 const { boolean } = require('boolean');
 const { setTimeout, setInterval } = require('safe-timers');
 
+const { isSchedule } = require('./job-utils');
+
 // bthreads requires us to do this for web workers (see bthreads docs for insight)
 threads.Buffer = Buffer;
 
@@ -101,6 +103,7 @@ class Bree extends EventEmitter {
     this.intervals = {};
 
     this.validateJob = this.validateJob.bind(this);
+    this.isSchedule = isSchedule;
     this.getWorkerMetadata = this.getWorkerMetadata.bind(this);
     this.run = this.run.bind(this);
     this.start = this.start.bind(this);
@@ -560,10 +563,6 @@ class Bree extends EventEmitter {
       );
 
     return value;
-  }
-
-  isSchedule(value) {
-    return typeof value === 'object' && Array.isArray(value.schedules);
   }
 
   getWorkerMetadata(name, meta = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ const isSANB = require('is-string-and-not-blank');
 const isValidPath = require('is-valid-path');
 const later = require('@breejs/later');
 const threads = require('bthreads');
-const { boolean } = require('boolean');
 const { setTimeout, setInterval } = require('safe-timers');
 
 const {
@@ -19,6 +18,7 @@ const {
   getHumanToMs,
   parseValue
 } = require('./job-utils');
+const buildJob = require('./job-builder');
 
 // bthreads requires us to do this for web workers (see bthreads docs for insight)
 threads.Buffer = Buffer;
@@ -194,119 +194,6 @@ class Bree extends EventEmitter {
   }
 
   // eslint-disable-next-line complexity
-  buildJob(job, config) {
-    if (isSANB(job)) {
-      const path = join(
-        config.root,
-        job.endsWith('.js') || job.endsWith('.mjs')
-          ? job
-          : `${job}.${config.defaultExtension}`
-      );
-
-      return {
-        name: job,
-        path,
-        timeout: config.timeout,
-        interval: config.interval
-      };
-    }
-
-    if (typeof job === 'function') {
-      const path = `(${job.toString()})()`;
-
-      return {
-        name: job.name,
-        path,
-        worker: { eval: true },
-        timeout: config.timeout,
-        interval: config.interval
-      };
-    }
-
-    // process job.path
-    if (typeof job.path === 'function') {
-      const path = `(${job.path.toString()})()`;
-
-      job.path = path;
-      job.worker = {
-        eval: true,
-        ...job.worker
-      };
-    } else {
-      const path = isSANB(job.path)
-        ? job.path
-        : join(
-            config.root,
-            job.name.endsWith('.js') || job.name.endsWith('.mjs')
-              ? job.name
-              : `${job.name}.${config.defaultExtension}`
-          );
-
-      if (isValidPath(path)) {
-        job.path = path;
-      } else {
-        // assume that it's a transformed eval string
-        job.worker = {
-          eval: true,
-          ...job.worker
-        };
-      }
-    }
-
-    if (typeof job.timeout !== 'undefined') {
-      job.timeout = this.parseValue(job.timeout);
-    }
-
-    if (typeof job.interval !== 'undefined') {
-      job.interval = this.parseValue(job.interval);
-    }
-
-    // build cron
-    if (typeof job.cron !== 'undefined') {
-      if (this.isSchedule(job.cron)) {
-        job.interval = job.cron;
-        // delete job.cron;
-      } else {
-        job.interval = later.parse.cron(
-          job.cron,
-          boolean(
-            typeof job.hasSeconds === 'undefined'
-              ? config.hasSeconds
-              : job.hasSeconds
-          )
-        );
-      }
-    }
-
-    // if timeout was undefined, cron was undefined,
-    // and date was undefined then set the default
-    // (as long as the default timeout is >= 0)
-    if (
-      Number.isFinite(config.timeout) &&
-      config.timeout >= 0 &&
-      typeof job.timeout === 'undefined' &&
-      typeof job.cron === 'undefined' &&
-      typeof job.date === 'undefined' &&
-      typeof job.interval === 'undefined'
-    )
-      job.timeout = config.timeout;
-
-    // if interval was undefined, cron was undefined,
-    // and date was undefined then set the default
-    // (as long as the default interval is > 0, or it was a schedule, or it was valid)
-    if (
-      ((Number.isFinite(config.interval) && config.interval > 0) ||
-        isSchedule(config.interval)) &&
-      typeof job.interval === 'undefined' &&
-      typeof job.cron === 'undefined' &&
-      typeof job.date === 'undefined'
-    )
-      job.interval = config.interval;
-
-    return job;
-  }
-
-  // eslint-disable-next-line complexity
   validateJob(job, i, isAdd = false) {
     const errors = [];
     const names = [];
@@ -368,7 +255,7 @@ class Bree extends EventEmitter {
           throw new Error(`Job #${i + 1} "${job}" path missing: ${path}`);
       }
 
-      return this.buildJob(job, this.config);
+      return buildJob(job, this.config);
     }
 
     // job is a function
@@ -382,7 +269,7 @@ class Bree extends EventEmitter {
 
       if (errors.length > 0) throw combineErrors(errors);
 
-      return this.buildJob(job, this.config);
+      return buildJob(job, this.config);
     }
 
     // use a prefix for errors
@@ -591,7 +478,7 @@ class Bree extends EventEmitter {
 
     if (errors.length > 0) throw combineErrors(errors);
 
-    return this.buildJob(job, this.config);
+    return buildJob(job, this.config);
   }
 
   getWorkerMetadata(name, meta = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const threads = require('bthreads');
 const { boolean } = require('boolean');
 const { setTimeout, setInterval } = require('safe-timers');
 
-const { isSchedule } = require('./job-utils');
+const { isSchedule, getName } = require('./job-utils');
 
 // bthreads requires us to do this for web workers (see bthreads docs for insight)
 threads.Buffer = Buffer;
@@ -111,6 +111,8 @@ class Bree extends EventEmitter {
     this.add = this.add.bind(this);
     this.remove = this.remove.bind(this);
 
+    this.getName = getName;
+
     // validate root (sync check)
     if (isSANB(this.config.root)) {
       /* istanbul ignore next */
@@ -184,12 +186,6 @@ class Bree extends EventEmitter {
     if (errors.length > 0) throw combineErrors(errors);
 
     debug('this.config.jobs', this.config.jobs);
-  }
-
-  getName(job) {
-    if (isSANB(job)) return job;
-    if (typeof job === 'object' && isSANB(job.name)) return job.name;
-    if (typeof job === 'function' && isSANB(job.name)) return job.name;
   }
 
   // eslint-disable-next-line complexity

--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,7 @@ class Bree extends EventEmitter {
     for (let j = 0; j < this.config.jobs.length; j++) {
       const name = this.getName(this.config.jobs[j]);
       if (!name) {
-        errors.push(new Error(`Job #${i + 1} is missing a name`));
+        errors.push(new Error(`Job #${j + 1} is missing a name`));
         continue;
       }
 

--- a/src/job-builder.js
+++ b/src/job-builder.js
@@ -1,0 +1,121 @@
+const { join } = require('path');
+const isSANB = require('is-string-and-not-blank');
+const isValidPath = require('is-valid-path');
+const { boolean } = require('boolean');
+const later = require('@breejs/later');
+const { isSchedule, parseValue } = require('./job-utils');
+
+// eslint-disable-next-line complexity
+const buildJob = (job, config) => {
+  if (isSANB(job)) {
+    const path = join(
+      config.root,
+      job.endsWith('.js') || job.endsWith('.mjs')
+        ? job
+        : `${job}.${config.defaultExtension}`
+    );
+
+    return {
+      name: job,
+      path,
+      timeout: config.timeout,
+      interval: config.interval
+    };
+  }
+
+  if (typeof job === 'function') {
+    const path = `(${job.toString()})()`;
+
+    return {
+      name: job.name,
+      path,
+      worker: { eval: true },
+      timeout: config.timeout,
+      interval: config.interval
+    };
+  }
+
+  // process job.path
+  if (typeof job.path === 'function') {
+    const path = `(${job.path.toString()})()`;
+
+    job.path = path;
+    job.worker = {
+      eval: true,
+      ...job.worker
+    };
+  } else {
+    const path = isSANB(job.path)
+      ? job.path
+      : join(
+          config.root,
+          job.name.endsWith('.js') || job.name.endsWith('.mjs')
+            ? job.name
+            : `${job.name}.${config.defaultExtension}`
+        );
+
+    if (isValidPath(path)) {
+      job.path = path;
+    } else {
+      // assume that it's a transformed eval string
+      job.worker = {
+        eval: true,
+        ...job.worker
+      };
+    }
+  }
+
+  if (typeof job.timeout !== 'undefined') {
+    job.timeout = parseValue(job.timeout);
+  }
+
+  if (typeof job.interval !== 'undefined') {
+    job.interval = parseValue(job.interval);
+  }
+
+  // build cron
+  if (typeof job.cron !== 'undefined') {
+    if (isSchedule(job.cron)) {
+      job.interval = job.cron;
+      // delete job.cron;
+    } else {
+      job.interval = later.parse.cron(
+        job.cron,
+        boolean(
+          typeof job.hasSeconds === 'undefined'
+            ? config.hasSeconds
+            : job.hasSeconds
+        )
+      );
+    }
+  }
+
+  // if timeout was undefined, cron was undefined,
+  // and date was undefined then set the default
+  // (as long as the default timeout is >= 0)
+  if (
+    Number.isFinite(config.timeout) &&
+    config.timeout >= 0 &&
+    typeof job.timeout === 'undefined' &&
+    typeof job.cron === 'undefined' &&
+    typeof job.date === 'undefined' &&
+    typeof job.interval === 'undefined'
+  )
+    job.timeout = config.timeout;
+
+  // if interval was undefined, cron was undefined,
+  // and date was undefined then set the default
+  // (as long as the default interval is > 0, or it was a schedule, or it was valid)
+  if (
+    ((Number.isFinite(config.interval) && config.interval > 0) ||
+      isSchedule(config.interval)) &&
+    typeof job.interval === 'undefined' &&
+    typeof job.cron === 'undefined' &&
+    typeof job.date === 'undefined'
+  )
+    job.interval = config.interval;
+
+  return job;
+};
+
+module.exports = buildJob;

--- a/src/job-utils.js
+++ b/src/job-utils.js
@@ -1,3 +1,6 @@
+const ms = require('ms');
+const humanInterval = require('human-interval');
+const later = require('@breejs/later');
 const isSANB = require('is-string-and-not-blank');
 
 const isSchedule = (value) => {
@@ -10,5 +13,32 @@ const getName = (job) => {
   if (typeof job === 'function' && isSANB(job.name)) return job.name;
 };
 
+const getHumanToMs = (_value) => {
+  const value = humanInterval(_value);
+  if (Number.isNaN(value)) return ms(_value);
+  return value;
+};
+
+const parseValue = (value) => {
+  if (value === false) return value;
+
+  if (this.isSchedule(value)) return value;
+
+  if (isSANB(value)) {
+    const schedule = later.schedule(later.parse.text(value));
+    if (schedule.isValid()) return later.parse.text(value);
+    value = getHumanToMs(value);
+  }
+
+  if (!Number.isFinite(value) || value < 0)
+    throw new Error(
+      `Value ${value} must be a finite number >= 0 or a String parseable by \`later.parse.text\` (see <https://breejs.github.io/later/parsers.html#text> for examples)`
+    );
+
+  return value;
+};
+
 module.exports.isSchedule = isSchedule;
 module.exports.getName = getName;
+module.exports.getHumanToMs = getHumanToMs;
+module.exports.parseValue = parseValue;

--- a/src/job-utils.js
+++ b/src/job-utils.js
@@ -38,7 +38,22 @@ const parseValue = (value) => {
   return value;
 };
 
+const getJobNames = (jobs, excludeIndex) => {
+  const names = [];
+
+  for (const [i, job] of jobs.entries()) {
+    if (i === excludeIndex) continue;
+
+    const name = this.getName(job);
+
+    if (name) names.push(name);
+  }
+
+  return names;
+};
+
 module.exports.isSchedule = isSchedule;
 module.exports.getName = getName;
 module.exports.getHumanToMs = getHumanToMs;
 module.exports.parseValue = parseValue;
+module.exports.getJobNames = getJobNames;

--- a/src/job-utils.js
+++ b/src/job-utils.js
@@ -44,7 +44,7 @@ const getJobNames = (jobs, excludeIndex) => {
   for (const [i, job] of jobs.entries()) {
     if (i === excludeIndex) continue;
 
-    const name = this.getName(job);
+    const name = getName(job);
 
     if (name) names.push(name);
   }

--- a/src/job-utils.js
+++ b/src/job-utils.js
@@ -1,5 +1,14 @@
+const isSANB = require('is-string-and-not-blank');
+
 const isSchedule = (value) => {
   return typeof value === 'object' && Array.isArray(value.schedules);
 };
 
+const getName = (job) => {
+  if (isSANB(job)) return job;
+  if (typeof job === 'object' && isSANB(job.name)) return job.name;
+  if (typeof job === 'function' && isSANB(job.name)) return job.name;
+};
+
 module.exports.isSchedule = isSchedule;
+module.exports.getName = getName;

--- a/src/job-utils.js
+++ b/src/job-utils.js
@@ -3,22 +3,45 @@ const humanInterval = require('human-interval');
 const later = require('@breejs/later');
 const isSANB = require('is-string-and-not-blank');
 
+/**
+ * Naively checks if passed value is of later.js schedule format (https://breejs.github.io/later/schedules.html)
+ *
+ * @param {*} value to check for schedule format
+ * @returns {boolean}
+ */
 const isSchedule = (value) => {
   return typeof value === 'object' && Array.isArray(value.schedules);
 };
 
+/**
+ * Extracts job name from job definition
+ *
+ * @param {string | Object | Function} job definition
+ * @returns {string}
+ */
 const getName = (job) => {
   if (isSANB(job)) return job;
   if (typeof job === 'object' && isSANB(job.name)) return job.name;
   if (typeof job === 'function' && isSANB(job.name)) return job.name;
 };
 
+/**
+ * Parses provided value into millisecond
+ *
+ * @param {string} _value
+ */
 const getHumanToMs = (_value) => {
   const value = humanInterval(_value);
   if (Number.isNaN(value)) return ms(_value);
   return value;
 };
 
+/**
+ * Parses schedule value into "later" schedule object or milliseconds
+ *
+ * @param {boolean | string | number | Object} value
+ * @returns {number | boolean | Object}
+ */
 const parseValue = (value) => {
   if (value === false) return value;
 
@@ -38,6 +61,14 @@ const parseValue = (value) => {
   return value;
 };
 
+/**
+ * Processes job objects extracting their names
+ * Can conditionaly skip records by their index
+ *
+ * @param {any[]} jobs
+ * @param {number} excludeIndex
+ * @returns {string[]} job names
+ */
 const getJobNames = (jobs, excludeIndex) => {
   const names = [];
 

--- a/src/job-utils.js
+++ b/src/job-utils.js
@@ -22,7 +22,7 @@ const getHumanToMs = (_value) => {
 const parseValue = (value) => {
   if (value === false) return value;
 
-  if (this.isSchedule(value)) return value;
+  if (isSchedule(value)) return value;
 
   if (isSANB(value)) {
     const schedule = later.schedule(later.parse.text(value));

--- a/src/job-utils.js
+++ b/src/job-utils.js
@@ -1,0 +1,5 @@
+const isSchedule = (value) => {
+  return typeof value === 'object' && Array.isArray(value.schedules);
+};
+
+module.exports.isSchedule = isSchedule;

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -133,18 +133,18 @@ const validateCron = (job, prefix, config) => {
   const errors = [];
 
   if (!isSchedule(job.cron)) {
+    // if `hasSeconds` was `true` then set `cronValidate` and inherit any existing options
+    const cronValidate = job.hasSeconds
+      ? cronValidateWithSeconds(job, config)
+      : config.cronValidate;
+
     //
     // validate cron pattern
     // (must support patterns such as `* * L * *` and `0 0/5 14 * * ?` (and aliases too)
     //
     //  <https://github.com/Airfooox/cron-validate/issues/67>
     //
-    const result = cron(
-      job.cron,
-      typeof job.cronValidate === 'undefined'
-        ? config.cronValidate
-        : job.cronValidate
-    );
+    const result = cron(job.cron, cronValidate);
 
     if (!result.isValid()) {
       // NOTE: it is always valid
@@ -284,12 +284,6 @@ const validate = (job, i, names = [], config = {}) => {
       )
     );
 
-  // if `hasSeconds` was `true` then set `cronValidate` and inherit any existing options
-  if (job.hasSeconds) {
-    job.cronValidate = cronValidateWithSeconds(job, config);
-  }
-
-  // validate cron
   if (typeof job.cron !== 'undefined') {
     errors.push(...validateCron(job, prefix, config));
   }

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -56,6 +56,31 @@ const validateFunctionJob = (job, i) => {
   if (errors.length > 0) throw combineErrors(errors);
 };
 
+const cronValidateWithSeconds = (job, config) => {
+  const preset =
+    job.cronValidate && job.cronValidate.preset
+      ? job.cronValidate.preset
+      : config.cronValidate && config.cronValidate.preset
+      ? config.cronValidate.preset
+      : 'default';
+  const override = {
+    ...(config.cronValidate && config.cronValidate.override
+      ? config.cronValidate.override
+      : {}),
+    ...(job.cronValidate && job.cronValidate.override
+      ? job.cronValidate.override
+      : {}),
+    useSeconds: true
+  };
+
+  return {
+    ...config.cronValidate,
+    ...job.cronValidate,
+    preset,
+    override
+  };
+};
+
 // eslint-disable-next-line complexity
 const validate = (job, i, names = [], config = {}) => {
   const errors = [];
@@ -202,27 +227,7 @@ const validate = (job, i, names = [], config = {}) => {
 
   // if `hasSeconds` was `true` then set `cronValidate` and inherit any existing options
   if (job.hasSeconds) {
-    const preset =
-      job.cronValidate && job.cronValidate.preset
-        ? job.cronValidate.preset
-        : config.cronValidate && config.cronValidate.preset
-        ? config.cronValidate.preset
-        : 'default';
-    const override = {
-      ...(config.cronValidate && config.cronValidate.override
-        ? config.cronValidate.override
-        : {}),
-      ...(job.cronValidate && job.cronValidate.override
-        ? job.cronValidate.override
-        : {}),
-      useSeconds: true
-    };
-    job.cronValidate = {
-      ...config.cronValidate,
-      ...job.cronValidate,
-      preset,
-      override
-    };
+    job.cronValidate = cronValidateWithSeconds(job, config);
   }
 
   // validate cron

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -1,0 +1,281 @@
+const fs = require('fs');
+const { join } = require('path');
+const combineErrors = require('combine-errors');
+const cron = require('cron-validate');
+const isSANB = require('is-string-and-not-blank');
+const isValidPath = require('is-valid-path');
+const threads = require('bthreads');
+
+const { getName, isSchedule, parseValue } = require('./job-utils');
+
+// eslint-disable-next-line complexity
+const validate = (job, i, names = [], config = {}) => {
+  const errors = [];
+
+  const name = getName(job);
+  if (!name) errors.push(new Error(`Job #${i + 1} is missing a name`));
+
+  // throw an error if duplicate job names
+  if (names.includes(name)) {
+    errors.push(
+      new Error(`Job #${i + 1} has a duplicate job name of ${getName(job)}`)
+    );
+  }
+
+  if (errors.length > 0) throw combineErrors(errors);
+
+  // support a simple string which we will transform to have a path
+  if (isSANB(job)) {
+    // don't allow a job to have the `index` file name
+    if (['index', 'index.js', 'index.mjs'].includes(job))
+      throw new Error(
+        'You cannot use the reserved job name of "index", "index.js", nor "index.mjs"'
+      );
+
+    if (!config.root) {
+      errors.push(
+        new Error(
+          `Job #${
+            i + 1
+          } "${job}" requires root directory option to auto-populate path`
+        )
+      );
+      throw combineErrors(errors);
+    }
+
+    const path = join(
+      config.root,
+      job.endsWith('.js') || job.endsWith('.mjs')
+        ? job
+        : `${job}.${config.defaultExtension}`
+    );
+
+    /* istanbul ignore next */
+    if (!threads.browser) {
+      const stats = fs.statSync(path);
+      if (!stats.isFile())
+        throw new Error(`Job #${i + 1} "${job}" path missing: ${path}`);
+    }
+
+    return;
+  }
+
+  // job is a function
+  if (typeof job === 'function') {
+    const path = `(${job.toString()})()`;
+    // can't be a built-in or bound function
+    if (path.includes('[native code]'))
+      errors.push(
+        new Error(`Job #${i + 1} can't be a bound or built-in function`)
+      );
+
+    if (errors.length > 0) throw combineErrors(errors);
+
+    return;
+  }
+
+  // use a prefix for errors
+  const prefix = `Job #${i + 1} named "${job.name}"`;
+
+  if (typeof job.path === 'function') {
+    const path = `(${job.path.toString()})()`;
+
+    // can't be a built-in or bound function
+    if (path.includes('[native code]'))
+      errors.push(
+        new Error(`Job #${i + 1} can't be a bound or built-in function`)
+      );
+  } else if (!isSANB(job.path) && !config.root) {
+    errors.push(
+      new Error(
+        `${prefix} requires root directory option to auto-populate path`
+      )
+    );
+  } else {
+    // validate path
+    const path = isSANB(job.path)
+      ? job.path
+      : join(
+          config.root,
+          job.name.endsWith('.js') || job.name.endsWith('.mjs')
+            ? job.name
+            : `${job.name}.${config.defaultExtension}`
+        );
+    if (isValidPath(path)) {
+      try {
+        /* istanbul ignore next */
+        if (!threads.browser) {
+          const stats = fs.statSync(path);
+          // eslint-disable-next-line max-depth
+          if (!stats.isFile())
+            throw new Error(`${prefix} path missing: ${path}`);
+        }
+      } catch (err) {
+        errors.push(err);
+      }
+    }
+  }
+
+  // don't allow users to mix interval AND cron
+  if (typeof job.interval !== 'undefined' && typeof job.cron !== 'undefined') {
+    errors.push(
+      new Error(`${prefix} cannot have both interval and cron configuration`)
+    );
+  }
+
+  // don't allow users to mix timeout AND date
+  if (typeof job.timeout !== 'undefined' && typeof job.date !== 'undefined')
+    errors.push(new Error(`${prefix} cannot have both timeout and date`));
+
+  // don't allow a job to have the `index` file name
+  if (['index', 'index.js', 'index.mjs'].includes(job.name)) {
+    errors.push(
+      new Error(
+        'You cannot use the reserved job name of "index", "index.js", nor "index.mjs"'
+      )
+    );
+
+    throw combineErrors(errors);
+  }
+
+  // validate date
+  if (typeof job.date !== 'undefined' && !(job.date instanceof Date))
+    errors.push(new Error(`${prefix} had an invalid Date of ${job.date}`));
+
+  // validate timeout
+  if (typeof job.timeout !== 'undefined') {
+    try {
+      parseValue(job.timeout);
+    } catch (err) {
+      errors.push(
+        combineErrors([
+          new Error(`${prefix} had an invalid timeout of ${job.timeout}`),
+          err
+        ])
+      );
+    }
+  }
+
+  // validate interval
+  if (typeof job.interval !== 'undefined') {
+    try {
+      parseValue(job.interval);
+    } catch (err) {
+      errors.push(
+        combineErrors([
+          new Error(`${prefix} had an invalid interval of ${job.interval}`),
+          err
+        ])
+      );
+    }
+  }
+
+  // validate hasSeconds
+  if (
+    typeof job.hasSeconds !== 'undefined' &&
+    typeof job.hasSeconds !== 'boolean'
+  )
+    errors.push(
+      new Error(
+        `${prefix} had hasSeconds value of ${job.hasSeconds} (it must be a Boolean)`
+      )
+    );
+
+  // validate cronValidate
+  if (
+    typeof job.cronValidate !== 'undefined' &&
+    typeof job.cronValidate !== 'object'
+  )
+    errors.push(
+      new Error(
+        `${prefix} had cronValidate value set, but it must be an Object`
+      )
+    );
+
+  // if `hasSeconds` was `true` then set `cronValidate` and inherit any existing options
+  if (job.hasSeconds) {
+    const preset =
+      job.cronValidate && job.cronValidate.preset
+        ? job.cronValidate.preset
+        : config.cronValidate && config.cronValidate.preset
+        ? config.cronValidate.preset
+        : 'default';
+    const override = {
+      ...(config.cronValidate && config.cronValidate.override
+        ? config.cronValidate.override
+        : {}),
+      ...(job.cronValidate && job.cronValidate.override
+        ? job.cronValidate.override
+        : {}),
+      useSeconds: true
+    };
+    job.cronValidate = {
+      ...config.cronValidate,
+      ...job.cronValidate,
+      preset,
+      override
+    };
+  }
+
+  // validate cron
+  if (typeof job.cron !== 'undefined') {
+    if (!isSchedule(job.cron)) {
+      //
+      // validate cron pattern
+      // (must support patterns such as `* * L * *` and `0 0/5 14 * * ?` (and aliases too)
+      //
+      //  <https://github.com/Airfooox/cron-validate/issues/67>
+      //
+      const result = cron(
+        job.cron,
+        typeof job.cronValidate === 'undefined'
+          ? config.cronValidate
+          : job.cronValidate
+      );
+
+      if (!result.isValid()) {
+        // NOTE: it is always valid
+        // const schedule = later.schedule(
+        //   later.parse.cron(
+        //     job.cron,
+        //     boolean(
+        //       typeof job.hasSeconds === 'undefined'
+        //         ? config.hasSeconds
+        //         : job.hasSeconds
+        //     )
+        //   )
+        // );
+        // if (schedule.isValid()) {
+        //   job.interval = schedule;
+        // } // else {
+        //   errors.push(
+        //     new Error(
+        //       `${prefix} had an invalid cron schedule (see <https://crontab.guru> if you need help)`
+        //     )
+        //   );
+        // }
+
+        for (const message of result.getError()) {
+          errors.push(
+            new Error(`${prefix} had an invalid cron pattern: ${message}`)
+          );
+        }
+      }
+    }
+  }
+
+  // validate closeWorkerAfterMs
+  if (
+    typeof job.closeWorkerAfterMs !== 'undefined' &&
+    (!Number.isFinite(job.closeWorkerAfterMs) || job.closeWorkerAfterMs <= 0)
+  )
+    errors.push(
+      new Error(
+        `${prefix} had an invalid closeWorkersAfterMs value of ${job.closeWorkersAfterMs} (it must be a finite number > 0)`
+      )
+    );
+
+  if (errors.length > 0) throw combineErrors(errors);
+};
+
+module.exports = validate;

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -174,11 +174,10 @@ const validateCron = (job, prefix, config) => {
   return errors;
 };
 
-// eslint-disable-next-line complexity
-const validate = (job, i, names = [], config = {}) => {
+const validateJobName = (job, i, names) => {
   const errors = [];
-
   const name = getName(job);
+
   if (!name) errors.push(new Error(`Job #${i + 1} is missing a name`));
 
   // throw an error if duplicate job names
@@ -187,6 +186,13 @@ const validate = (job, i, names = [], config = {}) => {
       new Error(`Job #${i + 1} has a duplicate job name of ${getName(job)}`)
     );
   }
+
+  return errors;
+};
+
+// eslint-disable-next-line complexity
+const validate = (job, i, names = [], config = {}) => {
+  const errors = validateJobName(job, i, names);
 
   if (errors.length > 0) throw combineErrors(errors);
 

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -230,8 +230,6 @@ const validate = (job, i, names = [], config = {}) => {
   const jobNameError = validateReservedJobName(job.name);
   if (jobNameError) errors.push(jobNameError);
 
-  if (errors.length > 0) throw combineErrors(errors);
-
   // validate date
   if (typeof job.date !== 'undefined' && !(job.date instanceof Date))
     errors.push(new Error(`${prefix} had an invalid Date of ${job.date}`));

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -8,6 +8,19 @@ const threads = require('bthreads');
 
 const { getName, isSchedule, parseValue } = require('./job-utils');
 
+const validateFunctionJob = (job, i) => {
+  const errors = [];
+
+  const path = `(${job.toString()})()`;
+  // can't be a built-in or bound function
+  if (path.includes('[native code]'))
+    errors.push(
+      new Error(`Job #${i + 1} can't be a bound or built-in function`)
+    );
+
+  if (errors.length > 0) throw combineErrors(errors);
+};
+
 // eslint-disable-next-line complexity
 const validate = (job, i, names = [], config = {}) => {
   const errors = [];
@@ -62,16 +75,7 @@ const validate = (job, i, names = [], config = {}) => {
 
   // job is a function
   if (typeof job === 'function') {
-    const path = `(${job.toString()})()`;
-    // can't be a built-in or bound function
-    if (path.includes('[native code]'))
-      errors.push(
-        new Error(`Job #${i + 1} can't be a bound or built-in function`)
-      );
-
-    if (errors.length > 0) throw combineErrors(errors);
-
-    return;
+    return validateFunctionJob(job, i);
   }
 
   // use a prefix for errors

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -174,14 +174,14 @@ const validateCron = (job, prefix, config) => {
   return errors;
 };
 
-const validateJobName = (job, i, names) => {
+const validateJobName = (job, i, reservedNames) => {
   const errors = [];
   const name = getName(job);
 
   if (!name) errors.push(new Error(`Job #${i + 1} is missing a name`));
 
   // throw an error if duplicate job names
-  if (names.includes(name)) {
+  if (reservedNames.includes(name)) {
     errors.push(
       new Error(`Job #${i + 1} has a duplicate job name of ${getName(job)}`)
     );

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -195,7 +195,6 @@ const validateJobName = (job, i, reservedNames) => {
   return errors;
 };
 
-// eslint-disable-next-line complexity
 const validate = (job, i, names = [], config = {}) => {
   const errors = validateJobName(job, i, names);
 
@@ -234,33 +233,20 @@ const validate = (job, i, names = [], config = {}) => {
   if (typeof job.date !== 'undefined' && !(job.date instanceof Date))
     errors.push(new Error(`${prefix} had an invalid Date of ${job.date}`));
 
-  // validate timeout
-  if (typeof job.timeout !== 'undefined') {
-    try {
-      parseValue(job.timeout);
-    } catch (err) {
-      errors.push(
-        combineErrors([
-          new Error(`${prefix} had an invalid timeout of ${job.timeout}`),
-          err
-        ])
-      );
+  ['timeout', 'interval'].forEach((prop) => {
+    if (typeof job[prop] !== 'undefined') {
+      try {
+        parseValue(job[prop]);
+      } catch (err) {
+        errors.push(
+          combineErrors([
+            new Error(`${prefix} had an invalid ${prop} of ${job.timeout}`),
+            err
+          ])
+        );
+      }
     }
-  }
-
-  // validate interval
-  if (typeof job.interval !== 'undefined') {
-    try {
-      parseValue(job.interval);
-    } catch (err) {
-      errors.push(
-        combineErrors([
-          new Error(`${prefix} had an invalid interval of ${job.interval}`),
-          err
-        ])
-      );
-    }
-  }
+  });
 
   // validate hasSeconds
   if (

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -8,14 +8,19 @@ const threads = require('bthreads');
 
 const { getName, isSchedule, parseValue } = require('./job-utils');
 
+const validateReservedJobName = (name) => {
+  // don't allow a job to have the `index` file name
+  if (['index', 'index.js', 'index.mjs'].includes(name))
+    return new Error(
+      'You cannot use the reserved job name of "index", "index.js", nor "index.mjs"'
+    );
+};
+
 const validateStringJob = (job, i, config) => {
   const errors = [];
 
-  // don't allow a job to have the `index` file name
-  if (['index', 'index.js', 'index.mjs'].includes(job))
-    throw new Error(
-      'You cannot use the reserved job name of "index", "index.js", nor "index.mjs"'
-    );
+  const jobNameError = validateReservedJobName(job);
+  if (jobNameError) throw jobNameError;
 
   if (!config.root) {
     errors.push(
@@ -222,16 +227,10 @@ const validate = (job, i, names = [], config = {}) => {
   if (typeof job.timeout !== 'undefined' && typeof job.date !== 'undefined')
     errors.push(new Error(`${prefix} cannot have both timeout and date`));
 
-  // don't allow a job to have the `index` file name
-  if (['index', 'index.js', 'index.mjs'].includes(job.name)) {
-    errors.push(
-      new Error(
-        'You cannot use the reserved job name of "index", "index.js", nor "index.mjs"'
-      )
-    );
+  const jobNameError = validateReservedJobName(job.name);
+  if (jobNameError) errors.push(jobNameError);
 
-    throw combineErrors(errors);
-  }
+  if (errors.length > 0) throw combineErrors(errors);
 
   // validate date
   if (typeof job.date !== 'undefined' && !(job.date instanceof Date))

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -195,7 +195,7 @@ const validateJobName = (job, i, reservedNames) => {
   return errors;
 };
 
-const validate = (job, i, names = [], config = {}) => {
+const validate = (job, i, names, config) => {
   const errors = validateJobName(job, i, names);
 
   if (errors.length > 0) throw combineErrors(errors);

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -289,3 +289,4 @@ const validate = (job, i, names = [], config = {}) => {
 };
 
 module.exports = validate;
+module.exports.cronValidateWithSeconds = cronValidateWithSeconds;

--- a/test/job-utils..js
+++ b/test/job-utils..js
@@ -1,0 +1,25 @@
+const test = require('ava');
+
+const jobUtils = require('../src/job-utils');
+
+test('getJobNames: returns all jobNames', (t) => {
+  const names = jobUtils.getJobNames(['hey', { name: 'hello' }]);
+
+  t.deepEqual(names, ['hey', 'hello']);
+});
+
+test('getJobNames: ignores name at specific index', (t) => {
+  const names = jobUtils.getJobNames(['hey', { name: 'hello' }, 'ignored'], 2);
+
+  t.deepEqual(names, ['hey', 'hello']);
+});
+
+test('getJobNames: ignores jobs with no valid name', (t) => {
+  const names = jobUtils.getJobNames([
+    'hey',
+    { name: 'hello' },
+    { prop: 'no name' }
+  ]);
+
+  t.deepEqual(names, ['hey', 'hello']);
+});

--- a/test/job-validator.js
+++ b/test/job-validator.js
@@ -1,0 +1,152 @@
+const test = require('ava');
+const path = require('path');
+
+const jobValidator = require('../src/job-validator');
+const root = path.join(__dirname, 'jobs');
+
+test('does not throw for valid object job', (t) => {
+  t.notThrows(() =>
+    jobValidator({ name: 'basic' }, 0, ['exists'], {
+      root,
+      defaultExtension: 'js'
+    })
+  );
+});
+
+test('does not throw for valid string job', (t) => {
+  t.notThrows(() =>
+    jobValidator('basic', 1, ['exists'], {
+      root,
+      defaultExtension: 'js'
+    })
+  );
+});
+
+test('throws for non-unique job name', (t) => {
+  t.throws(
+    () =>
+      jobValidator(
+        {
+          name: 'exists'
+        },
+        0,
+        ['exists'],
+        {
+          root: false
+        }
+      ),
+    {
+      message: /Job #1 has a duplicate job name of exists/
+    }
+  );
+});
+
+test('constructs default cronValidate configuration', (t) => {
+  const returned = jobValidator.cronValidateWithSeconds({ name: 'hello' }, {});
+
+  const expected = {
+    override: {
+      useSeconds: true
+    },
+    preset: 'default'
+  };
+
+  t.deepEqual(returned, expected);
+});
+
+test("prefers job's cronValidate configuration", (t) => {
+  const job = {
+    cronValidate: {
+      preset: 'custom'
+    }
+  };
+  const config = {
+    cronValidate: {
+      preset: 'global'
+    }
+  };
+
+  const returned = jobValidator.cronValidateWithSeconds(job, config);
+
+  const expected = {
+    override: {
+      useSeconds: true
+    },
+    preset: 'custom'
+  };
+
+  t.deepEqual(returned, expected);
+});
+
+test("prefers confg's cronValidate if none in job configuration", (t) => {
+  const job = {};
+
+  const config = {
+    cronValidate: {
+      preset: 'config-preset'
+    }
+  };
+
+  const returned = jobValidator.cronValidateWithSeconds(job, config);
+
+  const expected = {
+    override: {
+      useSeconds: true
+    },
+    preset: 'config-preset'
+  };
+
+  t.deepEqual(returned, expected);
+});
+
+test("uses confg's override cronValidate if none in job configuration", (t) => {
+  const job = {};
+
+  const config = {
+    cronValidate: {
+      override: {
+        useSeconds: true
+      }
+    }
+  };
+
+  const returned = jobValidator.cronValidateWithSeconds(job, config);
+
+  const expected = {
+    override: {
+      useSeconds: true
+    },
+    preset: 'default'
+  };
+
+  t.deepEqual(returned, expected);
+});
+
+test("prefers job's override cronValidate if none in job configuration", (t) => {
+  const job = {
+    cronValidate: {
+      override: {
+        useSeconds: true
+      }
+    }
+  };
+
+  const config = {
+    cronValidate: {
+      override: {
+        useSeconds: false
+      }
+    }
+  };
+
+  const returned = jobValidator.cronValidateWithSeconds(job, config);
+
+  const expected = {
+    override: {
+      useSeconds: true
+    },
+    preset: 'default'
+  };
+
+  t.deepEqual(returned, expected);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1437,12 +1437,6 @@ test('hasSeconds and job.hasSeconds', (t) => {
       useSeconds: true
     }
   });
-  t.deepEqual(bree.config.jobs[0].cronValidate, {
-    preset: 'default',
-    override: {
-      useSeconds: true
-    }
-  });
 });
 
 test('cronValidate and job.cronValidate', (t) => {


### PR DESCRIPTION
The main aim of this refactor is to simplify extremely complex `validateJob` method and make it easier to reason about job object construction/shape. Initially proposed in [this comment](https://github.com/breejs/bree/pull/51#issuecomment-731894764).

The plan is to:
- [x] Extract as methods used by validateJob function into separate module
- [x] Divide validateJob method into two separate parts - (1) validation and (2) job object construction
- [x] Extract  `buildJob` into separate module
- [x] Abstract away validateJob dependance on internal state of Bree instance - `this.config.jobs` 
- [x] Extract `validateJob` into separate module

Above should not change module's API or change it's behavior.