### PR TITLE
fix: cleaned up timeout references after job.date

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -717,6 +717,9 @@ class Bree extends EventEmitter {
               () => this.run(name),
               job.interval
             );
+          } else {
+            debug('job.date was scheduled to run only once', job);
+            delete this.timeouts[name];
           }
         }, job.date.getTime() - Date.now());
         return;

--- a/test/test.js
+++ b/test/test.js
@@ -631,9 +631,11 @@ test.serial('start > sets timeout if date is in the future', async (t) => {
   t.is(typeof bree.timeouts.infinite, 'undefined');
 
   bree.start('infinite');
+  t.is(typeof bree.timeouts.infinite, 'object');
+
   await clock.nextAsync();
 
-  t.is(typeof bree.timeouts.infinite, 'object');
+  t.is(typeof bree.timeouts.infinite, 'undefined');
 
   bree.stop();
   clock.uninstall();


### PR DESCRIPTION
When job is scheduled with `date` parameter and no interval/timeout parameters it would run only once. After execution there is no need to keep reference for it's timeout in `timeouts` lookup.

Usecase. In client apps it is sometimes needed to check if there is anything scheduled to be run in the future or is executing, something like:
```js
const isJobQueueEmpty = (bree) => {
    return (Object.keys(bree.workers).length === 0)
        && (Object.keys(bree.intervals).length === 0)
        && (Object.keys(bree.timeouts).length === 0);
};
``` 

Imo, it would be helpful to expose a similar to `isJobQueueEmpty` method directly from bree's API.