### PR TITLE
fix: made sure the jobs are stopped when removed

### DIFF
--- a/.lib.eslintrc
+++ b/.lib.eslintrc
@@ -6,7 +6,8 @@
     "no-unsafe-finally": "off",
     "no-func-assign": "off",
     "no-unused-vars": "off",
-    "no-constant-condition": "off"
+    "no-constant-condition": "off",
+    "no-fallthrough": "off"
   },
   "settings": {
     "polyfills": []

--- a/src/index.js
+++ b/src/index.js
@@ -563,16 +563,16 @@ class Bree extends EventEmitter {
     }
   }
 
-  remove(name) {
+  async remove(name) {
     const job = this.config.jobs.find((j) => j.name === name);
     if (!job) {
       throw new Error(`Job "${name}" does not exist`);
     }
 
-    this.config.jobs = this.config.jobs.filter((j) => j.name !== name);
+    // make sure it also closes any open workers
+    await this.stop(name);
 
-    // Make sure it also closes any open workers
-    this.stop(name);
+    this.config.jobs = this.config.jobs.filter((j) => j.name !== name);
   }
 }
 

--- a/test/remove.js
+++ b/test/remove.js
@@ -1,12 +1,12 @@
 const path = require('path');
-
+const delay = require('delay');
 const test = require('ava');
 
 const Bree = require('../src');
 
 const root = path.join(__dirname, 'jobs');
 
-test('successfully remove jobs', (t) => {
+test('successfully remove jobs', async (t) => {
   const bree = new Bree({
     root,
     jobs: ['basic', 'infinite']
@@ -14,16 +14,35 @@ test('successfully remove jobs', (t) => {
 
   t.is(typeof bree.config.jobs[1], 'object');
 
-  bree.remove('infinite');
+  await bree.remove('infinite');
 
   t.is(typeof bree.config.jobs[1], 'undefined');
 });
 
-test('fails if job does not exist', (t) => {
+test('remove > successfully remove and stop jobs', async (t) => {
+  const bree = new Bree({
+    root,
+    jobs: ['loop']
+  });
+  bree.start('loop');
+  await delay(10);
+
+  t.is(bree.config.jobs[0].name, 'loop');
+  t.true(typeof bree.workers.loop === 'object');
+
+  await bree.remove('loop');
+
+  t.is(typeof bree.config.jobs[0], 'undefined');
+  t.is(typeof bree.workers.loop, 'undefined');
+});
+
+test('remove > fails if job does not exist', async (t) => {
   const bree = new Bree({
     root,
     jobs: ['infinite']
   });
 
-  t.throws(() => bree.remove('basic'), { message: /Job .* does not exist/ });
+  await t.throwsAsync(() => bree.remove('basic'), {
+    message: /Job .* does not exist/
+  });
 });


### PR DESCRIPTION
After calling remove method there was no way to make sure the job execution has stopped completely (important when there's a need to "reschedule" a job under same name). The stop method is `async` and await not only makes sure it finished execution, it also catches errors which are thrown during the execution. There was an exception thrown under the hood from `getJobMetadata` method, that's why  `this.config.jobs.filter` had to come **after** `this.stop`.