### PR TITLE
add timezone support

### DIFF
--- a/src/job-builder.js
+++ b/src/job-builder.js
@@ -2,7 +2,7 @@ const { join } = require('path');
 const isSANB = require('is-string-and-not-blank');
 const isValidPath = require('is-valid-path');
 const { boolean } = require('boolean');
-const later = require('@breejs/later');
+const later = require('./later-tz-patch');
 const { isSchedule, parseValue } = require('./job-utils');
 
 later.date.localTime();
@@ -129,7 +129,7 @@ const buildJob = (job, config) => {
     job.interval = config.interval;
   }
 
-  if (isSANB(config.timezone)) {
+  if (isSANB(config.timezone) && !job.timezone) {
     job.timezone = config.timezone;
   }
 

--- a/src/job-builder.js
+++ b/src/job-builder.js
@@ -17,24 +17,34 @@ const buildJob = (job, config) => {
         : `${job}.${config.defaultExtension}`
     );
 
-    return {
+    const jobObject = {
       name: job,
       path,
       timeout: config.timeout,
       interval: config.interval
     };
+    if (isSANB(config.timezone)) {
+      jobObject.timezone = config.timezone;
+    }
+
+    return jobObject;
   }
 
   if (typeof job === 'function') {
     const path = `(${job.toString()})()`;
 
-    return {
+    const jobObject = {
       name: job.name,
       path,
       worker: { eval: true },
       timeout: config.timeout,
       interval: config.interval
     };
+    if (isSANB(config.timezone)) {
+      jobObject.timezone = config.timezone;
+    }
+
+    return jobObject;
   }
 
   // Process job.path
@@ -117,6 +127,10 @@ const buildJob = (job, config) => {
     typeof job.date === 'undefined'
   ) {
     job.interval = config.interval;
+  }
+
+  if (isSANB(config.timezone)) {
+    job.timezone = config.timezone;
   }
 
   return job;

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -306,6 +306,16 @@ const validate = (job, i, names, config) => {
     );
   }
 
+  if (isSANB(job.timezone) && !['local', 'system'].includes(job.timezone)) {
+    try {
+      // `.toLocaleString()` will throw a `RangeError` if `timeZone` string
+      // is bogus or not supported by the environment.
+      new Date().toLocaleString('ia', { timeZone: job.timezone });
+    } catch (err) {
+      errors.push(err);
+    }
+  }
+
   if (errors.length > 0) {
     throw combineErrors(errors);
   }

--- a/src/job-validator.js
+++ b/src/job-validator.js
@@ -311,8 +311,12 @@ const validate = (job, i, names, config) => {
       // `.toLocaleString()` will throw a `RangeError` if `timeZone` string
       // is bogus or not supported by the environment.
       new Date().toLocaleString('ia', { timeZone: job.timezone });
-    } catch (err) {
-      errors.push(err);
+    } catch {
+      errors.push(
+        new Error(
+          `${prefix} had an invalid or unsupported timezone specified: ${job.timezone}`
+        )
+      );
     }
   }
 

--- a/src/later-tz-patch.js
+++ b/src/later-tz-patch.js
@@ -1,0 +1,83 @@
+const later = require('@breejs/later');
+
+later.setTimeout = (fn, sched, timezone) => {
+  const s = later.schedule(sched);
+  let t;
+  if (fn) {
+    scheduleTimeout();
+  }
+
+  function scheduleTimeout() {
+    const date = new Date();
+    const now = date.getTime();
+
+    const next = (() => {
+      if (!timezone || ['local', 'system'].includes(timezone)) {
+        return s.next(2, now);
+      }
+
+      const offsetHours = (date
+        .toLocaleString('ia', { timeZone: timezone, timeZoneName: 'short' })
+        .match(/[+-]\d+$/) || ['0'])[0];
+      const offsetMillis = Number(offsetHours) * 60 * 6e4;
+      const adjustedNow = new Date(now + offsetMillis);
+
+      return s.next(2, adjustedNow).map((time) => {
+        const schedMillis = new Date(time).getTime();
+        const adjustedMillis = schedMillis + offsetMillis;
+        return new Date(adjustedMillis);
+      });
+    })();
+
+    if (!next[0]) {
+      t = undefined;
+      return;
+    }
+
+    let diff = next[0].getTime() - now;
+    if (diff < 1e3) {
+      diff = next[1] ? next[1].getTime() - now : 1e3;
+    }
+
+    t =
+      diff < 2147483647
+        ? setTimeout(fn, diff)
+        : setTimeout(scheduleTimeout, 2147483647);
+  } // scheduleTimeout()
+
+  return {
+    isDone() {
+      return !t;
+    },
+    clear() {
+      clearTimeout(t);
+    }
+  };
+}; // setTimeout()
+
+later.setInterval = function (fn, sched, timezone) {
+  if (!fn) {
+    return;
+  }
+
+  let t = later.setTimeout(scheduleTimeout, sched, timezone);
+  let done = t.isDone();
+  function scheduleTimeout() {
+    if (!done) {
+      fn();
+      t = later.setTimeout(scheduleTimeout, sched, timezone);
+    }
+  }
+
+  return {
+    isDone() {
+      return t.isDone();
+    },
+    clear() {
+      done = true;
+      t.clear();
+    }
+  };
+}; // setInterval()
+
+module.exports = later;

--- a/src/later-tz-patch.js
+++ b/src/later-tz-patch.js
@@ -9,10 +9,12 @@ function getOffset(date, zone) {
     }) //=> ie. "8/22/2021, 24:30:00 EDT"
     .match(/(\d+)\/(\d+)\/(\d+),? (\d+):(\d+):(\d+)/)
     .map((n) => (n.length === 1 ? '0' + n : n));
+
   const zdate = new Date(
-    `${yr}-${m}-${d}T${hr.replace('24', '00')}:${min}:${s}`
+    `${yr}-${m}-${d}T${hr.replace('24', '00')}:${min}:${s}Z`
   );
-  return date.getTime() - zdate.getTime() + date.getTimezoneOffset() * 6e4;
+
+  return date.getTime() - zdate.getTime();
 } // getOffset()
 
 later.setTimeout = (fn, sched, timezone) => {

--- a/src/later-tz-patch.js
+++ b/src/later-tz-patch.js
@@ -1,5 +1,20 @@
 const later = require('@breejs/later');
 
+function getOffset(date, zone) {
+  const [, m, d, yr, hr, min, s] = date
+    .toLocaleString('en-US', {
+      hour12: false,
+      timeZone: zone,
+      timeZoneName: 'short'
+    }) //=> ie. "8/22/2021, 24:30:00 EDT"
+    .match(/(\d+)\/(\d+)\/(\d+),? (\d+):(\d+):(\d+)/)
+    .map((n) => (n.length === 1 ? '0' + n : n));
+  const zdate = new Date(
+    `${yr}-${m}-${d}T${hr.replace('24', '00')}:${min}:${s}`
+  );
+  return date.getTime() - zdate.getTime() + date.getTimezoneOffset() * 6e4;
+} // getOffset()
+
 later.setTimeout = (fn, sched, timezone) => {
   const s = later.schedule(sched);
   let t;
@@ -16,25 +31,11 @@ later.setTimeout = (fn, sched, timezone) => {
         return s.next(2, now);
       }
 
-      // The number of minutes returned by getTimezoneOffset() is positive if the local
-      // time zone is behind UTC, and negative if the local time zone is ahead of UTC.
-      // Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset#negative_values_and_positive_values
       const localOffsetMillis = date.getTimezoneOffset() * 6e4;
-
-      // Get specified timezone's UTC offset
-      const offsetTime = date
-        .toLocaleString('ia', { timeZone: timezone, timeZoneName: 'short' })
-        .match(/([+-])(\d+):?(\d*)$/) || ['0'];
-      // convert time to milliseconds and negate
-      // for convenience ie. +5:30 => -19800000
-      const offsetMillis = -Number(
-        offsetTime[1] +
-          (Number(offsetTime[2]) * 36e5 + Number(offsetTime[3]) * 6e4)
-      );
+      const offsetMillis = getOffset(date, timezone);
 
       // Specified timezone has the same offset as local timezone.
-      // ie. datetime = 2021-08-22T11:30:00.000-04:00 => America/Nassau
-      //     zone     = America/New_York => 2021-08-22T11:30:00.000-04:00
+      // ie. America/New_York = America/Nassau = GMT-4
       if (offsetMillis === localOffsetMillis) {
         return s.next(2, now);
       }
@@ -42,14 +43,17 @@ later.setTimeout = (fn, sched, timezone) => {
       // Offsets differ, adjust current time to match what
       // it should've been for the specified timezone.
       const adjustedNow = new Date(now + localOffsetMillis - offsetMillis);
-      return (s.next(2, adjustedNow) || []).map((time) => {
-        // adjust scheduled times to match their intended timezone
-        // ie. scheduled = 2021-08-22T11:30:00.000-04:00 => America/New_York
-        //     intended  = 2021-08-22T11:30:00.000-05:00 => America/Mexico_City
-        const schedMillis = time.getTime();
-        const adjustedMillis = schedMillis + offsetMillis - localOffsetMillis;
-        return new Date(adjustedMillis);
-      });
+
+      return (s.next(2, adjustedNow) || /* istanbul ignore next */ []).map(
+        (time) => {
+          // adjust scheduled times to match their intended timezone
+          // ie. scheduled = 2021-08-22T11:30:00.000-04:00 => America/New_York
+          //     intended  = 2021-08-22T11:30:00.000-05:00 => America/Mexico_City
+          const schedMillis = time.getTime();
+          const adjustedMillis = schedMillis + offsetMillis - localOffsetMillis;
+          return new Date(adjustedMillis);
+        }
+      );
     })();
 
     if (!next[0]) {
@@ -86,6 +90,7 @@ later.setInterval = function (fn, sched, timezone) {
   let t = later.setTimeout(scheduleTimeout, sched, timezone);
   let done = t.isDone();
   function scheduleTimeout() {
+    /* istanbul ignore else */
     if (!done) {
       fn();
       t = later.setTimeout(scheduleTimeout, sched, timezone);

--- a/src/later-tz-patch.js
+++ b/src/later-tz-patch.js
@@ -16,6 +16,11 @@ later.setTimeout = (fn, sched, timezone) => {
         return s.next(2, now);
       }
 
+      // The number of minutes returned by getTimezoneOffset() is positive if the local
+      // time zone is behind UTC, and negative if the local time zone is ahead of UTC.
+      // Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset#negative_values_and_positive_values
+      const localOffsetMillis = date.getTimezoneOffset() * 6e4;
+
       // Get specified timezone's UTC offset
       const offsetTime = date
         .toLocaleString('ia', { timeZone: timezone, timeZoneName: 'short' })
@@ -26,11 +31,6 @@ later.setTimeout = (fn, sched, timezone) => {
         offsetTime[1] +
           (Number(offsetTime[2]) * 36e5 + Number(offsetTime[3]) * 6e4)
       );
-
-      // The number of minutes returned by getTimezoneOffset() is positive if the local
-      // time zone is behind UTC, and negative if the local time zone is ahead of UTC.
-      // Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset#negative_values_and_positive_values
-      const localOffsetMillis = date.getTimezoneOffset() * 6e4;
 
       // Specified timezone has the same offset as local timezone.
       // ie. datetime = 2021-08-22T11:30:00.000-04:00 => America/Nassau

--- a/test/job-builder.js
+++ b/test/job-builder.js
@@ -209,7 +209,7 @@ test(
   { name: 'basic', timezone: 'America/New_York' },
   { timezone: 'local' },
   {
-    timezone: 'local',
+    timezone: 'America/New_York',
     name: 'basic',
     path: `${root}/basic.js`,
     timeout: 0

--- a/test/job-builder.js
+++ b/test/job-builder.js
@@ -160,3 +160,58 @@ test(
   { interval: 10 },
   { name: 'basic', path: `${root}/basic.js`, timeout: 0, interval: 10 }
 );
+
+test(
+  'job as file inherits timezone from config',
+  job,
+  'basic',
+  { timezone: 'local' },
+  {
+    timezone: 'local',
+    name: 'basic',
+    path: `${root}/basic.js`,
+    timeout: 0,
+    interval: 0
+  }
+);
+
+test(
+  'job as function inherits timezone from config',
+  job,
+  basic,
+  { timezone: 'local' },
+  {
+    timezone: 'local',
+    name: 'basic',
+    path: `(${basic.toString()})()`,
+    timeout: 0,
+    interval: 0,
+    worker: { eval: true }
+  }
+);
+
+test(
+  'job as object inherits timezone from config',
+  job,
+  { name: 'basic' },
+  { timezone: 'local' },
+  {
+    timezone: 'local',
+    name: 'basic',
+    path: `${root}/basic.js`,
+    timeout: 0
+  }
+);
+
+test(
+  'job as object retains its own timezone',
+  job,
+  { name: 'basic', timezone: 'America/New_York' },
+  { timezone: 'local' },
+  {
+    timezone: 'local',
+    name: 'basic',
+    path: `${root}/basic.js`,
+    timeout: 0
+  }
+);

--- a/test/job-validator.js
+++ b/test/job-validator.js
@@ -481,3 +481,46 @@ test('throws if closeWorkerAfterMs is invalid', (t) => {
     }
   );
 });
+
+test('succeeds if job.timezone is valid', (t) => {
+  t.notThrows(() =>
+    jobValidator(
+      { name: 'basic', timezone: 'America/New_York' },
+      0,
+      ['exists'],
+      {
+        root,
+        defaultExtension: 'js'
+      }
+    )
+  );
+});
+
+test('accepts "local" and "system" as valid job.timezone options', (t) => {
+  t.notThrows(() =>
+    jobValidator({ name: 'basic', timezone: 'local' }, 0, ['exists'], {
+      root,
+      defaultExtension: 'js'
+    })
+  );
+  t.notThrows(() =>
+    jobValidator({ name: 'basic', timezone: 'system' }, 0, ['exists'], {
+      root,
+      defaultExtension: 'js'
+    })
+  );
+});
+
+test('throws if job.timezone is invalid or unsupported', (t) => {
+  t.throws(
+    () =>
+      jobValidator({ name: 'basic', timezone: 'bogus' }, 0, ['exists'], {
+        root,
+        defaultExtension: 'js'
+      }),
+    {
+      message:
+        'Job #1 named "basic" had an invalid or unsupported timezone specified: bogus'
+    }
+  );
+});

--- a/test/later-tz-patch.js
+++ b/test/later-tz-patch.js
@@ -1,0 +1,139 @@
+const test = require('ava');
+const FakeTimers = require('@sinonjs/fake-timers');
+
+const later = require('../src/later-tz-patch');
+
+const noop = () => {
+  /* noop */
+};
+
+test('.setTimeout() accepts IANA timezone strings', (t) => {
+  t.notThrows(() => {
+    const s = later.parse.recur().every(2).second();
+    later.setTimeout(() => t.pass(), s, 'America/New_York');
+  });
+});
+
+test('.setTimeout() accepts "local" and "system" as valid timezone strings', (t) => {
+  t.notThrows(() => {
+    const s = later.parse.recur().every(2).second();
+    later.setTimeout(() => t.pass(), s, 'local');
+    later.setTimeout(() => t.pass(), s, 'system');
+  });
+});
+
+test('.setTimeout() throws RangeError when given an invalid or unsupported timezone string', (t) => {
+  t.throws(
+    () => {
+      const s = later.parse.recur().every(2).second();
+      later.setTimeout(() => t.pass(), s, 'bogus_zone');
+    },
+    {
+      name: 'RangeError',
+      message: 'Invalid time zone specified: bogus_zone'
+    }
+  );
+});
+
+test('.setTimeout() adjusts scheduled time if the local timezone is ahead of the one specified', (t) => {
+  const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
+  const timezone = 'America/Mexico_City'; // time now = 2021-08-22T09:30:00.000-05:00
+  const msHalfHour = 36e5 / 2;
+
+  // Run half hour later.
+  // Intended datetime: 2021-08-22T10:00:00.000-05:00
+  // But instead, we don't specify timezone here
+  const intendedDatetime = '2021-08-22T10:00:00.000';
+  // And so, `new Date()` will use it's local timezone:
+  // Assumed datetime: 2021-08-22T10:00:00.000-05:00
+  const assumedTimezone = '-04:00';
+  const s = later.parse
+    .recur()
+    .on(new Date(intendedDatetime + assumedTimezone))
+    .fullDate();
+
+  const clock = FakeTimers.install({
+    now: datetimeNow.getTime()
+  });
+
+  // hijack `setTimeout()` to test `timeout` param
+  const setTimeout_og = global.setTimeout;
+  global.setTimeout = (fn, ms) => {
+    // Time now: 2021-08-22T09:30:00.000-05:00
+    // Intended run time: 2021-08-22T10:00:00.000-05:00
+    t.is(ms, msHalfHour);
+  };
+
+  later.setTimeout(noop, s, timezone);
+
+  // reset
+  global.setTimeout = setTimeout_og;
+  clock.uninstall();
+});
+
+test('.setTimeout() adjusts scheduled time if the local timezone is behind of the one specified', (t) => {
+  const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
+  const timezone = 'Europe/Athens'; // time now = 2021-08-22T17:30:00.000+03:00
+  const msHalfHour = 36e5 / 2;
+
+  // Run half hour later.
+  // Intended datetime: 2021-08-22T18:00:00.000-05:00
+  // But instead, we don't specify timezone here
+  const intendedDatetime = '2021-08-22T18:00:00.000';
+  // And so, `new Date()` will use it's local timezone:
+  // Assumed datetime: 2021-08-22T18:00:00.000-05:00
+  const assumedTimezone = '-04:00';
+  const s = later.parse
+    .recur()
+    .on(new Date(intendedDatetime + assumedTimezone))
+    .fullDate();
+
+  const clock = FakeTimers.install({
+    now: datetimeNow.getTime()
+  });
+
+  // hijack `setTimeout()` to test `timeout` param
+  const setTimeout_og = global.setTimeout;
+  global.setTimeout = (fn, ms) => {
+    // Time now: 2021-08-22T09:30:00.000-05:00
+    // Intended run time: 2021-08-22T10:00:00.000-05:00
+    t.is(ms, msHalfHour);
+  };
+
+  later.setTimeout(noop, s, timezone);
+
+  // reset
+  global.setTimeout = setTimeout_og;
+  clock.uninstall();
+});
+
+test('.setTimeout() does not adjust time if specified and local timezones are the same', (t) => {
+  const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
+  const timezone = 'America/New_York';
+  const msOneHour = 36e5;
+
+  // Intended run time is one hour later: 2021-08-22 at 11:30, New York time
+  const intendedRunTime = '2021-08-22T11:30:00.000-04:00';
+
+  const s = later.parse.recur().on(new Date(intendedRunTime)).fullDate();
+
+  const clock = FakeTimers.install({
+    now: datetimeNow.getTime()
+  });
+
+  // hijack `setTimeout()` to test `timeout` param
+  const setTimeout_og = global.setTimeout;
+  global.setTimeout = (fn, ms) => {
+    // intended time
+    // America/Mexico_City => 2021-08-22T11:30:00.000-05:00
+    // America/New_York => 2021-08-22T12:30:00.000-04:00
+    //
+    t.is(ms, msOneHour);
+  };
+
+  later.setTimeout(noop, s, timezone);
+
+  // reset
+  global.setTimeout = setTimeout_og;
+  clock.uninstall();
+});

--- a/test/later-tz-patch.js
+++ b/test/later-tz-patch.js
@@ -29,8 +29,7 @@ test('.setTimeout() throws RangeError when given an invalid or unsupported timez
       later.setTimeout(() => t.pass(), s, 'bogus_zone');
     },
     {
-      name: 'RangeError',
-      message: 'Invalid time zone specified: bogus_zone'
+      name: 'RangeError'
     }
   );
 });

--- a/test/later-tz-patch.js
+++ b/test/later-tz-patch.js
@@ -42,14 +42,14 @@ test.serial(
 
     const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
     const timezone = 'America/Mexico_City'; // time now = 2021-08-22T09:30:00.000-05:00
-    const msHalfHour = 36e5 / 2;
+    const msHalfHour = 18e5;
 
     // Run half hour later.
     // Intended datetime: 2021-08-22T10:00:00.000-05:00
     // But instead, we don't specify timezone here
     const intendedDatetime = '2021-08-22T10:00:00.000';
     // And so, `new Date()` will use it's local timezone:
-    // Assumed datetime: 2021-08-22T10:00:00.000-05:00
+    // Assumed datetime: 2021-08-22T10:00:00.000-04:00
     const assumedTimezone = '-04:00';
     const s = later.parse
       .recur()
@@ -59,10 +59,9 @@ test.serial(
     const clock = FakeTimers.install({
       now: datetimeNow.getTime()
     });
+    clock.Date.prototype.getTimezoneOffset = () => 240;
 
     clock.setTimeout = (fn, ms) => {
-      // Time now: 2021-08-22T09:30:00.000-05:00
-      // Intended run time: 2021-08-22T10:00:00.000-05:00
       t.is(ms, msHalfHour);
     };
 
@@ -79,14 +78,14 @@ test.serial(
 
     const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
     const timezone = 'Europe/Athens'; // time now = 2021-08-22T17:30:00.000+03:00
-    const msHalfHour = 36e5 / 2;
+    const msHalfHour = 18e5;
 
     // Run half hour later.
-    // Intended datetime: 2021-08-22T18:00:00.000-05:00
+    // Intended datetime: 2021-08-22T18:00:00.000+03:00
     // But instead, we don't specify timezone here
     const intendedDatetime = '2021-08-22T18:00:00.000';
     // And so, `new Date()` will use it's local timezone:
-    // Assumed datetime: 2021-08-22T18:00:00.000-05:00
+    // Assumed datetime: 2021-08-22T18:00:00.000-04:00
     const assumedTimezone = '-04:00';
     const s = later.parse
       .recur()
@@ -96,10 +95,9 @@ test.serial(
     const clock = FakeTimers.install({
       now: datetimeNow.getTime()
     });
+    clock.Date.prototype.getTimezoneOffset = () => 240;
 
     clock.setTimeout = (fn, ms) => {
-      // Time now: 2021-08-22T09:30:00.000-05:00
-      // Intended run time: 2021-08-22T10:00:00.000-05:00
       t.is(ms, msHalfHour);
     };
 
@@ -126,11 +124,9 @@ test.serial(
     const clock = FakeTimers.install({
       now: datetimeNow.getTime()
     });
+    clock.Date.prototype.getTimezoneOffset = () => 240;
 
     clock.setTimeout = (fn, ms) => {
-      // intended time
-      // America/Mexico_City => 2021-08-22T11:30:00.000-05:00
-      // America/New_York => 2021-08-22T12:30:00.000-04:00
       t.is(ms, msOneHour);
     };
 

--- a/test/later-tz-patch.js
+++ b/test/later-tz-patch.js
@@ -127,7 +127,6 @@ test('.setTimeout() does not adjust time if specified and local timezones are th
     // intended time
     // America/Mexico_City => 2021-08-22T11:30:00.000-05:00
     // America/New_York => 2021-08-22T12:30:00.000-04:00
-    //
     t.is(ms, msOneHour);
   };
 

--- a/test/later-tz-patch.js
+++ b/test/later-tz-patch.js
@@ -35,104 +35,107 @@ test('.setTimeout() throws RangeError when given an invalid or unsupported timez
   );
 });
 
-test('.setTimeout() adjusts scheduled time if the local timezone is ahead of the one specified', (t) => {
-  const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
-  const timezone = 'America/Mexico_City'; // time now = 2021-08-22T09:30:00.000-05:00
-  const msHalfHour = 36e5 / 2;
+test.serial(
+  '.setTimeout() adjusts scheduled time if the local timezone is ahead of the one specified',
+  (t) => {
+    t.plan(1);
 
-  // Run half hour later.
-  // Intended datetime: 2021-08-22T10:00:00.000-05:00
-  // But instead, we don't specify timezone here
-  const intendedDatetime = '2021-08-22T10:00:00.000';
-  // And so, `new Date()` will use it's local timezone:
-  // Assumed datetime: 2021-08-22T10:00:00.000-05:00
-  const assumedTimezone = '-04:00';
-  const s = later.parse
-    .recur()
-    .on(new Date(intendedDatetime + assumedTimezone))
-    .fullDate();
+    const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
+    const timezone = 'America/Mexico_City'; // time now = 2021-08-22T09:30:00.000-05:00
+    const msHalfHour = 36e5 / 2;
 
-  const clock = FakeTimers.install({
-    now: datetimeNow.getTime()
-  });
+    // Run half hour later.
+    // Intended datetime: 2021-08-22T10:00:00.000-05:00
+    // But instead, we don't specify timezone here
+    const intendedDatetime = '2021-08-22T10:00:00.000';
+    // And so, `new Date()` will use it's local timezone:
+    // Assumed datetime: 2021-08-22T10:00:00.000-05:00
+    const assumedTimezone = '-04:00';
+    const s = later.parse
+      .recur()
+      .on(new Date(intendedDatetime + assumedTimezone))
+      .fullDate();
 
-  // hijack `setTimeout()` to test `timeout` param
-  const setTimeout_og = global.setTimeout;
-  global.setTimeout = (fn, ms) => {
-    // Time now: 2021-08-22T09:30:00.000-05:00
-    // Intended run time: 2021-08-22T10:00:00.000-05:00
-    t.is(ms, msHalfHour);
-  };
+    const clock = FakeTimers.install({
+      now: datetimeNow.getTime()
+    });
 
-  later.setTimeout(noop, s, timezone);
+    clock.setTimeout = (fn, ms) => {
+      // Time now: 2021-08-22T09:30:00.000-05:00
+      // Intended run time: 2021-08-22T10:00:00.000-05:00
+      t.is(ms, msHalfHour);
+    };
 
-  // reset
-  global.setTimeout = setTimeout_og;
-  clock.uninstall();
-});
+    later.setTimeout(noop, s, timezone);
 
-test('.setTimeout() adjusts scheduled time if the local timezone is behind of the one specified', (t) => {
-  const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
-  const timezone = 'Europe/Athens'; // time now = 2021-08-22T17:30:00.000+03:00
-  const msHalfHour = 36e5 / 2;
+    clock.uninstall();
+  }
+);
 
-  // Run half hour later.
-  // Intended datetime: 2021-08-22T18:00:00.000-05:00
-  // But instead, we don't specify timezone here
-  const intendedDatetime = '2021-08-22T18:00:00.000';
-  // And so, `new Date()` will use it's local timezone:
-  // Assumed datetime: 2021-08-22T18:00:00.000-05:00
-  const assumedTimezone = '-04:00';
-  const s = later.parse
-    .recur()
-    .on(new Date(intendedDatetime + assumedTimezone))
-    .fullDate();
+test.serial(
+  '.setTimeout() adjusts scheduled time if the local timezone is behind of the one specified',
+  (t) => {
+    t.plan(1);
 
-  const clock = FakeTimers.install({
-    now: datetimeNow.getTime()
-  });
+    const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
+    const timezone = 'Europe/Athens'; // time now = 2021-08-22T17:30:00.000+03:00
+    const msHalfHour = 36e5 / 2;
 
-  // hijack `setTimeout()` to test `timeout` param
-  const setTimeout_og = global.setTimeout;
-  global.setTimeout = (fn, ms) => {
-    // Time now: 2021-08-22T09:30:00.000-05:00
-    // Intended run time: 2021-08-22T10:00:00.000-05:00
-    t.is(ms, msHalfHour);
-  };
+    // Run half hour later.
+    // Intended datetime: 2021-08-22T18:00:00.000-05:00
+    // But instead, we don't specify timezone here
+    const intendedDatetime = '2021-08-22T18:00:00.000';
+    // And so, `new Date()` will use it's local timezone:
+    // Assumed datetime: 2021-08-22T18:00:00.000-05:00
+    const assumedTimezone = '-04:00';
+    const s = later.parse
+      .recur()
+      .on(new Date(intendedDatetime + assumedTimezone))
+      .fullDate();
 
-  later.setTimeout(noop, s, timezone);
+    const clock = FakeTimers.install({
+      now: datetimeNow.getTime()
+    });
 
-  // reset
-  global.setTimeout = setTimeout_og;
-  clock.uninstall();
-});
+    clock.setTimeout = (fn, ms) => {
+      // Time now: 2021-08-22T09:30:00.000-05:00
+      // Intended run time: 2021-08-22T10:00:00.000-05:00
+      t.is(ms, msHalfHour);
+    };
 
-test('.setTimeout() does not adjust time if specified and local timezones are the same', (t) => {
-  const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
-  const timezone = 'America/New_York';
-  const msOneHour = 36e5;
+    later.setTimeout(noop, s, timezone);
 
-  // Intended run time is one hour later: 2021-08-22 at 11:30, New York time
-  const intendedRunTime = '2021-08-22T11:30:00.000-04:00';
+    clock.uninstall();
+  }
+);
 
-  const s = later.parse.recur().on(new Date(intendedRunTime)).fullDate();
+test.serial(
+  '.setTimeout() does not adjust time if specified and local timezones are the same',
+  (t) => {
+    t.plan(1);
 
-  const clock = FakeTimers.install({
-    now: datetimeNow.getTime()
-  });
+    const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
+    const timezone = 'America/New_York';
+    const msOneHour = 36e5;
 
-  // hijack `setTimeout()` to test `timeout` param
-  const setTimeout_og = global.setTimeout;
-  global.setTimeout = (fn, ms) => {
-    // intended time
-    // America/Mexico_City => 2021-08-22T11:30:00.000-05:00
-    // America/New_York => 2021-08-22T12:30:00.000-04:00
-    t.is(ms, msOneHour);
-  };
+    // Intended run time is one hour later: 2021-08-22 at 11:30, New York time
+    const intendedRunTime = '2021-08-22T11:30:00.000-04:00';
 
-  later.setTimeout(noop, s, timezone);
+    const s = later.parse.recur().on(new Date(intendedRunTime)).fullDate();
 
-  // reset
-  global.setTimeout = setTimeout_og;
-  clock.uninstall();
-});
+    const clock = FakeTimers.install({
+      now: datetimeNow.getTime()
+    });
+
+    clock.setTimeout = (fn, ms) => {
+      // intended time
+      // America/Mexico_City => 2021-08-22T11:30:00.000-05:00
+      // America/New_York => 2021-08-22T12:30:00.000-04:00
+      t.is(ms, msOneHour);
+    };
+
+    later.setTimeout(noop, s, timezone);
+
+    clock.uninstall();
+  }
+);

--- a/test/start.js
+++ b/test/start.js
@@ -386,7 +386,9 @@ test('does not set interval if interval is 0', async (t) => {
   await bree.stop();
 });
 
-test('uses job.timezone to schedule a job', (t) => {
+test.serial('uses job.timezone to schedule a job', (t) => {
+  t.plan(3);
+
   const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
 
   const clock = FakeTimers.install({
@@ -418,8 +420,7 @@ test('uses job.timezone to schedule a job', (t) => {
     ]
   });
 
-  const setTimeout_og = global.setTimeout;
-  global.setTimeout = (fn, ms) => {
+  clock.setTimeout = (fn, ms) => {
     t.is(ms, 36e5);
   };
 
@@ -427,12 +428,12 @@ test('uses job.timezone to schedule a job', (t) => {
   bree.start('tz_interval');
   bree.start('tz_timeout');
 
-  // reset
-  global.setTimeout = setTimeout_og;
   clock.uninstall();
 });
 
-test('uses default timezone to schedule a job', (t) => {
+test.serial('uses default timezone to schedule a job', (t) => {
+  t.plan(6);
+
   const datetimeNow = new Date('2021-08-22T10:30:00.000-04:00'); // zone = America/New_York
 
   const clock = FakeTimers.install({
@@ -464,8 +465,7 @@ test('uses default timezone to schedule a job', (t) => {
 
   bree.config.jobs.forEach((job) => t.is(job.timezone, 'America/Mexico_City'));
 
-  const setTimeout_og = global.setTimeout;
-  global.setTimeout = (fn, ms) => {
+  clock.setTimeout = (fn, ms) => {
     t.is(ms, 18e5);
   };
 
@@ -473,7 +473,5 @@ test('uses default timezone to schedule a job', (t) => {
   bree.start('tz_interval');
   bree.start('tz_timeout');
 
-  // reset
-  global.setTimeout = setTimeout_og;
   clock.uninstall();
 });


### PR DESCRIPTION
Issue https://github.com/breejs/bree/issues/72

### Changelog
**Added:**
* Timezone support for scheduled job runs. Supports `cron`, `interval` and `timeout` schedules.
* A `timezone` option to instance options. Default value is `local`
* A `timezone` option to job options.

### Notes
This PR does not support timezone conversion for `job.date` yet because bree uses `safe-timers` for that instead of `@breejs/later`, where most of the tz work was done. It's fairly easy to support `job.date` as well, but I'm wondering whether it's necessary since `Date` covers that.