### PR TITLE
[feat] Add a "before worker created" event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -302,6 +302,7 @@ class Bree extends EventEmitter {
         return;
       }
 
+      this.emit('before worker created', name);
       debug('starting worker', name);
       const object = {
         ...(this.config.worker ? this.config.worker : {}),


### PR DESCRIPTION
As of today, Bree.js emits two events: one after the worker has been created, the other after it has been deleted.
Here's a really simple proposal in order to have another event, for example in order to allow modifications of data right before they're sent to the worker.