### PR TITLE
fix: logger types in constructor config

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -76,7 +76,7 @@ declare namespace Bree {
   type JobOptions = Required<Pick<Job, 'name'>> & Partial<Omit<Job, 'name'>>;
 
   interface BreeConfigs {
-    logger: Record<string, unknown>;
+    logger: Record<string, unknown> | boolean;
     root: string | boolean;
     silenceRootCheckError: boolean;
     doRootCheck: boolean;


### PR DESCRIPTION
When passing in `false` into `logger` in typescript, you'll receive an error saying it only accepts a `Record`. 