### PR TITLE
fix: correct type problem on rest parameter

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@ import { Timeout, Interval } from 'safe-timers';
 
 export = Bree;
 
-type AsyncFunction<A, O> = (...args: A) => Promise<O>;
+type AsyncFunction<A extends any[], O> = (...args: A) => Promise<O>;
 
 declare class Bree extends EventEmitter {
   config: Bree.BreeConfigs;


### PR DESCRIPTION
The error was:

    .../types/index.d.ts:9:29 - error TS2370: A rest parameter must be of an array type.

    9 type AsyncFunction<A, O> = (...args: A) => Promise<O>;
                                  ~~~~~~~~~~

So enforce the parameter to be some kind of array.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
