### PR TITLE
#202 Windows compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
 //
 const fs = require('fs');
 const EventEmitter = require('events');
+const { pathToFileURL } = require('url');
 const { Worker } = require('worker_threads');
 const { join, resolve } = require('path');
 const { debuglog } = require('util');
@@ -235,7 +236,13 @@ class Bree extends EventEmitter {
       try {
         const importPath = join(this.config.root, this.config.defaultRootIndex);
         debug('importPath', importPath);
-        const obj = await import(importPath);
+        const importUrl = pathToFileURL(importPath).toString();
+        debug('importUrl', importUrl);
+        // hint: import statement expect a esm-url-string, not a file-path-string (https://github.com/breejs/bree/issues/202)
+        // otherwise the following error is expected:
+        // Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data are supported by the default ESM loader.
+        // On Windows, absolute paths must be valid file:// URLs.
+        const obj = await import(importUrl);
         if (typeof obj.default !== 'object') {
           throw new ImportError(
             `Root index file missing default export at: ${importPath}`

--- a/test/job-builder.js
+++ b/test/job-builder.js
@@ -5,6 +5,8 @@ const later = require('@breejs/later');
 const jobBuilder = require('../src/job-builder');
 
 const root = path.join(__dirname, 'jobs');
+const jobPathBasic = path.join(root, 'basic.js');
+
 const baseConfig = {
   root,
   timeout: 0,
@@ -26,7 +28,7 @@ test(
   job,
   null,
   {},
-  { name: 'basic', path: `${root}/basic.js`, timeout: 0, interval: 0 }
+  { name: 'basic', path: jobPathBasic, timeout: 0, interval: 0 }
 );
 
 test(
@@ -34,7 +36,12 @@ test(
   job,
   'basic.js',
   {},
-  { name: 'basic.js', path: `${root}/basic.js`, timeout: 0, interval: 0 }
+  {
+    name: 'basic.js',
+    path: jobPathBasic,
+    timeout: 0,
+    interval: 0
+  }
 );
 
 function basic() {
@@ -74,7 +81,7 @@ test(
   job,
   { name: 'basic', path: '' },
   {},
-  { name: 'basic', path: `${root}/basic.js`, timeout: 0 }
+  { name: 'basic', path: jobPathBasic, timeout: 0 }
 );
 
 test(
@@ -82,15 +89,15 @@ test(
   job,
   { name: 'basic.js', path: '' },
   {},
-  { name: 'basic.js', path: `${root}/basic.js`, timeout: 0 }
+  { name: 'basic.js', path: jobPathBasic, timeout: 0 }
 );
 
 test(
   'job.path is path to file',
   job,
-  { path: `${root}/basic.js` },
+  { path: jobPathBasic },
   {},
-  { path: `${root}/basic.js`, timeout: 0 }
+  { path: jobPathBasic, timeout: 0 }
 );
 
 test(
@@ -104,26 +111,26 @@ test(
 test(
   'job.timeout is value',
   job,
-  { path: `${root}/basic.js`, timeout: 10 },
+  { path: jobPathBasic, timeout: 10 },
   {},
-  { path: `${root}/basic.js`, timeout: 10 }
+  { path: jobPathBasic, timeout: 10 }
 );
 
 test(
   'job.interval is value',
   job,
-  { path: `${root}/basic.js`, interval: 10 },
+  { path: jobPathBasic, interval: 10 },
   {},
-  { path: `${root}/basic.js`, interval: 10 }
+  { path: jobPathBasic, interval: 10 }
 );
 
 test(
   'job.cron is value',
   job,
-  { path: `${root}/basic.js`, cron: '* * * * *' },
+  { path: jobPathBasic, cron: '* * * * *' },
   {},
   {
-    path: `${root}/basic.js`,
+    path: jobPathBasic,
     cron: '* * * * *',
     interval: later.parse.cron('* * * * *')
   }
@@ -132,10 +139,10 @@ test(
 test(
   'job.cron is value with hasSeconds config',
   job,
-  { path: `${root}/basic.js`, cron: '* * * * *', hasSeconds: false },
+  { path: jobPathBasic, cron: '* * * * *', hasSeconds: false },
   {},
   {
-    path: `${root}/basic.js`,
+    path: jobPathBasic,
     cron: '* * * * *',
     interval: later.parse.cron('* * * * *'),
     hasSeconds: false
@@ -145,10 +152,10 @@ test(
 test(
   'job.cron is schedule',
   job,
-  { path: `${root}/basic.js`, cron: later.parse.cron('* * * * *') },
+  { path: jobPathBasic, cron: later.parse.cron('* * * * *') },
   {},
   {
-    path: `${root}/basic.js`,
+    path: jobPathBasic,
     cron: later.parse.cron('* * * * *'),
     interval: later.parse.cron('* * * * *')
   }
@@ -159,7 +166,7 @@ test(
   job,
   { name: 'basic', interval: undefined },
   { interval: 10 },
-  { name: 'basic', path: `${root}/basic.js`, timeout: 0, interval: 10 }
+  { name: 'basic', path: jobPathBasic, timeout: 0, interval: 10 }
 );
 
 test(
@@ -170,7 +177,7 @@ test(
   {
     timezone: 'local',
     name: 'basic',
-    path: `${root}/basic.js`,
+    path: jobPathBasic,
     timeout: 0,
     interval: 0
   }
@@ -199,7 +206,7 @@ test(
   {
     timezone: 'local',
     name: 'basic',
-    path: `${root}/basic.js`,
+    path: jobPathBasic,
     timeout: 0
   }
 );
@@ -212,7 +219,7 @@ test(
   {
     timezone: 'America/New_York',
     name: 'basic',
-    path: `${root}/basic.js`,
+    path: jobPathBasic,
     timeout: 0
   }
 );


### PR DESCRIPTION
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

Fixes #202 

**Version impact:**

patch, there shouldn't be a need to increase minor or major version numbers

**About the changes:**

- transforms the given file-path-string to a url-string, so that the `import`-Statement requirement for its parameter is satisfied (index.js, line 239-245)
- fixed tests to use file-path-strings as required by the doc (`job.path` usage in `test/job-builder.js` didn't comply)
- tested with NodeJS 16.x (LTS), Node 18.x (LTS) on Windows 7 and 10, also Ubuntu (via VM)