### PR TITLE
feat: enhance extend function to dynamically handle async plugins

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -111,9 +111,15 @@ declare namespace Bree {
     jobs?: Array<string | (() => void) | JobOptions>;
   };
 
-  type PluginFunc<T = unknown> = (options: T, c: typeof Bree) => void;
+  type PluginFunc<T = unknown> = (
+    options: T,
+    c: typeof Bree
+  ) => void | Promise<void>;
 
-  function extend<T = unknown>(plugin: PluginFunc<T>, options?: T): Bree;
+  function extend<T = unknown>(
+    plugin: PluginFunc<T>,
+    options?: T
+  ): Bree | Promise<Bree>;
 
   type BreeLogger = {
     info: (...args: any[]) => any;

--- a/src/index.js
+++ b/src/index.js
@@ -786,9 +786,25 @@ class Bree extends EventEmitter {
 }
 
 // plugins inspired by Dayjs
-Bree.extend = (plugin, options) => {
+Bree.extend = function (plugin, options) {
   if (!plugin.$i) {
-    // install plugin only once
+    // Check if the plugin is an async function
+    if (plugin.constructor.name === 'AsyncFunction') {
+      // Override the extend function to be async
+      Bree.extend = async function (plugin, options) {
+        if (!plugin.$i) {
+          await plugin(options, Bree);
+          plugin.$i = true;
+        }
+
+        return Bree;
+      };
+
+      // Call the overridden async extend function
+      return Bree.extend(plugin, options);
+    }
+
+    // Synchronous plugin logic
     plugin(options, Bree);
     plugin.$i = true;
   }


### PR DESCRIPTION
**Summary:**
This pull request enhances the `extend` function in the Bree library to dynamically handle both synchronous and asynchronous plugins. The function now returns `Promise<Bree>` if the plugin is asynchronous and `Bree` if it is synchronous.

**Changes Made:**
1. **Dynamic Return Type:** Modified the `extend` function to return `Promise<Bree>` for async plugins and `Bree` for synchronous plugins.
2. **Type Definitions:** Added type definitions to support both synchronous and asynchronous plugin functions.
3. **Compatibility:** Ensured compatibility with existing synchronous plugins while enabling seamless integration of asynchronous plugins.
4. **Type Safety:** Improved type safety and flexibility in plugin management.

**Checklist:**
- [ ] I have ensured my pull request is not behind the main or master branch of the original repository.
- [ ] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commmitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

**Additional Notes:**
- This enhancement allows for more flexible plugin integration, supporting modern JavaScript practices with async functions.
- The implementation ensures backward compatibility, so existing synchronous plugins will continue to work without modification.