### PR TITLE
fix: use cron-validate 1.4.5 always due to breaking change on 2.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@breejs/later": "^4.2.0",
     "boolean": "^3.2.0",
     "combine-errors": "^3.0.3",
-    "cron-validate": "^1.4.5",
+    "cron-validate": "~1.4.5",
     "human-interval": "^2.0.1",
     "is-string-and-not-blank": "^0.0.2",
     "is-valid-path": "^0.1.1",


### PR DESCRIPTION
By default now bree tries to fetch 2.x cron-validate package which is not compatible. I set package.json to always use 1.4.5.

## Checklist

- [X] I have ensured my pull request is not behind the main or master branch of the original repository.
- [X] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [X] I have written a commit message that passes commitlint linting.
- [X] I have ensured that my code changes pass linting tests.
- [X] I have ensured that my code changes pass unit tests.
- [X] I have described my pull request and the reasons for code changes along with context if necessary.
