### PR TITLE
Fix type for timeout option

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -71,7 +71,7 @@ declare namespace Bree {
   type Job = {
     name: string;
     path: string | (() => void);
-    timeout: number | string | boolean;
+    timeout: number | string | false;
     interval: number | string;
     date?: Date;
     cron?: string;


### PR DESCRIPTION
There is a runtime check which will throw an error if timeout is set to true, along the lines of:

`error: Job #1 named "exampleJob" had an invalid timeout of true`

This minor tweak will ensure type safety at build/dev time too.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x  I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
