### PR TITLE
replace ms with ms-tiny

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "cron-validate": "^1.5.3",
     "human-interval": "^2.0.1",
     "is-invalid-path": "^0.1.0",
-    "ms": "^2.1.3",
+    "ms-tiny": "^1.1.0",
     "p-wait-for": "3",
     "safe-timers": "^1.1.0"
   },

--- a/src/job-utils.js
+++ b/src/job-utils.js
@@ -1,6 +1,6 @@
 const humanInterval = require('human-interval');
 const later = require('@breejs/later');
-const ms = require('ms');
+const ms = require('ms-tiny');
 
 /**
  * Returns true if `val` is a string and it's not blank.
@@ -41,7 +41,15 @@ const getName = (job) => {
  */
 const getHumanToMs = (_value) => {
   const value = humanInterval(_value);
-  if (Number.isNaN(value)) return ms(_value);
+  if (Number.isNaN(value)) {
+    try {
+      return ms(_value);
+    } catch (err) {
+      throw new Error(
+        `Value "${_value}" is not parseable as a time interval (see <https://breejs.github.io/later/parsers.html#text> for examples)`
+      );
+    }
+  }
   return value;
 };
 


### PR DESCRIPTION
ms has no TypeScript types and no ESM exports.

ms-tiny has the same API, ships ESM + CJS with built-in types. 833 bytes gzipped, zero deps.

ms-tiny throws on invalid input instead of returning undefined. Added try-catch where the code relied on the undefined return.

https://npmgraph.js.org/?q=ms-tiny